### PR TITLE
Kotlin版本更新至 `v1.7.20`

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.10" />
+    <option name="version" value="1.7.20" />
   </component>
 </project>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,8 +8,8 @@ repositories {
     gradlePluginPortal()
 }
 
-val kotlinVersion = "1.7.10"
-val dokkaPluginVersion = "1.7.10"
+val kotlinVersion = "1.7.20"
+val dokkaPluginVersion = "1.7.20"
 
 dependencies {
     api(gradleApi())

--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -1,5 +1,5 @@
 object IProject {
-    const val VERSION = "0.0.4"
+    const val VERSION = "0.0.5"
     const val GROUP = "love.forte.plugin.suspend-transform"
     const val DESCRIPTION = "Generate platform-compatible functions for Kotlin suspend functions"
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/IrFunctionUtils.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/IrFunctionUtils.kt
@@ -2,9 +2,6 @@ package love.forte.plugin.suspendtrans.utils
 
 import org.jetbrains.kotlin.backend.common.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.backend.common.ir.createImplicitParameterDeclarationWithWrappedDescriptor
-import org.jetbrains.kotlin.backend.common.ir.isOverridable
-import org.jetbrains.kotlin.backend.common.ir.isStatic
 import org.jetbrains.kotlin.backend.jvm.ir.fileParent
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -16,9 +13,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrGetFieldImpl
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.typeOrNull
-import org.jetbrains.kotlin.ir.util.constructors
-import org.jetbrains.kotlin.ir.util.originalFunction
-import org.jetbrains.kotlin.ir.util.parentClassOrNull
+import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
 import java.util.*


### PR DESCRIPTION
注意：更新后可能会无法与 `v0.0.4` 兼容：Kotlin `v1.7.20` 与 `v1.7.10` 相比，编译器插件内发生了不兼容的API变动。