### PR TITLE
针对 CoroutineScope 类型的参数的填充优化

### DIFF
--- a/.run/PublishAllToLocal.run.xml
+++ b/.run/PublishAllToLocal.run.xml
@@ -1,0 +1,29 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="PublishAllToLocal" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="SIMBOT_LOCAL" value="true" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="publishAllPublicationsToMavenLocalRepository" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <ForceTestExec>false</ForceTestExec>
+    <method v="2" />
+  </configuration>
+</component>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 val kotlinVersion = "1.8.21"
-val dokkaPluginVersion = "1.8.10"
+val dokkaPluginVersion = "1.8.20"
 val gradleCommon = "0.0.11"
 
 dependencies {

--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -8,7 +8,7 @@ object IProject : ProjectDetail() {
     const val DESCRIPTION = "Generate platform-compatible functions for Kotlin suspend functions"
     const val HOMEPAGE = "https://github.com/ForteScarlet/kotlin-suspend-transform-compiler-plugin"
 
-    override val version: Version = version(0, 3, 2)
+    override val version: Version = version(0, 4, 0)
 
     override val homepage: String get() = HOMEPAGE
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/ir/SuspendTransformTransformer.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/ir/SuspendTransformTransformer.kt
@@ -210,52 +210,14 @@ private fun generateTransformBodyForFunction(
             val owner = transformTargetFunctionCall.owner
 
             // CoroutineScope
-            if (owner.valueParameters.size > 1) {
-                owner.valueParameters.forEachIndexed { index, valueParameter ->
-                    if (index == 0) {
-                        return@forEachIndexed
-                    }
+            val ownerValueParameters = owner.valueParameters
 
+            if (ownerValueParameters.size > 1) {
+                for (index in 1..ownerValueParameters.lastIndex) {
+                    val valueParameter = ownerValueParameters[index]
                     val type = valueParameter.type
                     tryResolveCoroutineScopeValueParameter(type, context, function, owner, this@irBlockBody, index)
                 }
-
-//                val secondType = owner.valueParameters[1].type
-//                val coroutineScopeTypeName = "kotlinx.coroutines.CoroutineScope".fqn
-//                val coroutineScopeTypeClassId = ClassId.topLevel("kotlinx.coroutines.CoroutineScope".fqn)
-//                val coroutineScopeTypeNameUnsafe = coroutineScopeTypeName.toUnsafe()
-//                if (secondType.isClassType(coroutineScopeTypeNameUnsafe)) {
-//                    function.dispatchReceiverParameter?.also { dispatchReceiverParameter ->
-//                        context.referenceClass(coroutineScopeTypeClassId)?.also { coroutineScopeRef ->
-////                            irGet(dispatchReceiverParameter)
-////                            irAs(irGet(dispatchReceiverParameter), coroutineScopeRef).safeAs<>()
-//                            if (dispatchReceiverParameter.type.isSubtypeOfClass(coroutineScopeRef)) {
-//                                // put 'this' to second arg
-//                                putValueArgument(1, irGet(dispatchReceiverParameter))
-//                            } else {
-//                                // scope safe cast
-//                                val scopeType = coroutineScopeRef.defaultType
-//
-//                                val scopeParameter = owner.valueParameters.getOrNull(1)
-//
-//                                if (scopeParameter?.type?.isNullable() == true) {
-//                                    val irSafeAs = IrTypeOperatorCallImpl(
-//                                        startOffset,
-//                                        endOffset,
-//                                        scopeType,
-//                                        IrTypeOperator.SAFE_CAST,
-//                                        scopeType,
-//                                        irGet(dispatchReceiverParameter)
-//                                    )
-//
-//                                    putValueArgument(1, irSafeAs)
-//                                }
-////                                irAs(irGet(dispatchReceiverParameter), coroutineScopeRef.defaultType)
-//                            }
-//                        }
-//                    }
-//                }
-
             }
 
         })
@@ -269,8 +231,9 @@ private val coroutineScopeTypeNameUnsafe = coroutineScopeTypeName.toUnsafe()
 /**
  * 解析类型为 CoroutineScope 的参数。
  * 如果当前参数类型为 CoroutineScope:
- * - 如果当前 dispatcher 即为 CoroutineScope 类型，将其填充
- * - 如果当前 dispatcher 不是 CoroutineScope 类型，但是此参数可以为 null，则使用 safe-cast 将 dispatcher 转化为 CoroutineScope ( `dispatcher as? CoroutineScope` )
+ * - 如果当前 receiver 即为 CoroutineScope 类型，将其填充
+ * - 如果当前 receiver 不是 CoroutineScope 类型，但是此参数可以为 null，
+ *   则使用 safe-cast 将 receiver 转化为 CoroutineScope ( `dispatcher as? CoroutineScope` )
  * - 其他情况忽略此参数（适用于此参数有默认值的情况）
  */
 private fun IrCall.tryResolveCoroutineScopeValueParameter(
@@ -281,34 +244,33 @@ private fun IrCall.tryResolveCoroutineScopeValueParameter(
     builderWithScope: IrBuilderWithScope,
     index: Int
 ) {
-    if (type.isClassType(coroutineScopeTypeNameUnsafe)) {
-        function.dispatchReceiverParameter?.also { dispatchReceiverParameter ->
-            context.referenceClass(coroutineScopeTypeClassId)?.also { coroutineScopeRef ->
-//                            irGet(dispatchReceiverParameter)
-//                            irAs(irGet(dispatchReceiverParameter), coroutineScopeRef).safeAs<>()
-                if (dispatchReceiverParameter.type.isSubtypeOfClass(coroutineScopeRef)) {
-                    // put 'this' to second arg
-                    putValueArgument(index, builderWithScope.irGet(dispatchReceiverParameter))
-                } else {
-                    // scope safe cast
-                    val scopeType = coroutineScopeRef.defaultType
+    if (!type.isClassType(coroutineScopeTypeNameUnsafe)) {
+        return
+    }
 
-                    val scopeParameter = owner.valueParameters.getOrNull(1)
+    function.dispatchReceiverParameter?.also { dispatchReceiverParameter ->
+        context.referenceClass(coroutineScopeTypeClassId)?.also { coroutineScopeRef ->
+            if (dispatchReceiverParameter.type.isSubtypeOfClass(coroutineScopeRef)) {
+                // put 'this' to the arg
+                putValueArgument(index, builderWithScope.irGet(dispatchReceiverParameter))
+            } else {
+                val scopeType = coroutineScopeRef.defaultType
 
-                    if (scopeParameter?.type?.isNullable() == true) {
-                        val irSafeAs = IrTypeOperatorCallImpl(
-                            startOffset,
-                            endOffset,
-                            scopeType,
-                            IrTypeOperator.SAFE_CAST,
-                            scopeType,
-                            builderWithScope.irGet(dispatchReceiverParameter)
-                        )
+                val scopeParameter = owner.valueParameters.getOrNull(1)
 
-                        putValueArgument(index, irSafeAs)
-                    }
-//                                irAs(irGet(dispatchReceiverParameter), coroutineScopeRef.defaultType)
+                if (scopeParameter?.type?.isNullable() == true) {
+                    val irSafeAs = IrTypeOperatorCallImpl(
+                        startOffset,
+                        endOffset,
+                        scopeType,
+                        IrTypeOperator.SAFE_CAST,
+                        scopeType,
+                        builderWithScope.irGet(dispatchReceiverParameter)
+                    )
+
+                    putValueArgument(index, irSafeAs)
                 }
+//                                irAs(irGet(dispatchReceiverParameter), coroutineScopeRef.defaultType)
             }
         }
     }

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/ir/SuspendTransformTransformer.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/ir/SuspendTransformTransformer.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
 import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.isNullable
 import org.jetbrains.kotlin.ir.types.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.isAnnotationWithEqualFqName
@@ -229,18 +230,22 @@ private fun generateTransformBodyForFunction(
                             } else {
                                 // TODO scope safe cast
                                 val scopeType = coroutineScopeRef.defaultType
+
+                                if (getValueArgument(1)?.type?.isNullable() == true) {
+                                    val irSafeAs = IrTypeOperatorCallImpl(
+                                        startOffset,
+                                        endOffset,
+                                        scopeType,
+                                        IrTypeOperator.SAFE_CAST,
+                                        scopeType,
+                                        irGet(dispatchReceiverParameter)
+                                    )
+
+                                    putValueArgument(1, irSafeAs)
+                                }
+
 //                                irAs(irGet(dispatchReceiverParameter), coroutineScopeRef.defaultType)
 
-                                val irSafeAs = IrTypeOperatorCallImpl(
-                                    startOffset,
-                                    endOffset,
-                                    scopeType,
-                                    IrTypeOperator.SAFE_CAST,
-                                    scopeType,
-                                    irGet(dispatchReceiverParameter)
-                                )
-
-                                putValueArgument(1, irSafeAs)
                             }
                         }
                     }

--- a/runtime/suspend-transform-runtime/src/jvmMain/kotlin/love/forte/plugin/suspendtrans/runtime/RunInSuspendJvm.kt
+++ b/runtime/suspend-transform-runtime/src/jvmMain/kotlin/love/forte/plugin/suspendtrans/runtime/RunInSuspendJvm.kt
@@ -74,7 +74,7 @@ private val transformer: FutureTransformer =
 @Suppress("FunctionName")
 public fun <T> `$runInAsync$`(
     block: suspend () -> T,
-    scope: CoroutineScope? = null //`$CoroutineScope4J$`
+    scope: CoroutineScope? = null
 ): CompletableFuture<T> {
     return transformer.trans(scope ?: `$CoroutineScope4J$`, block)
 }

--- a/runtime/suspend-transform-runtime/src/jvmMain/kotlin/love/forte/plugin/suspendtrans/runtime/RunInSuspendJvm.kt
+++ b/runtime/suspend-transform-runtime/src/jvmMain/kotlin/love/forte/plugin/suspendtrans/runtime/RunInSuspendJvm.kt
@@ -74,9 +74,9 @@ private val transformer: FutureTransformer =
 @Suppress("FunctionName")
 public fun <T> `$runInAsync$`(
     block: suspend () -> T,
-    scope: CoroutineScope = `$CoroutineScope4J$`
+    scope: CoroutineScope? = null //`$CoroutineScope4J$`
 ): CompletableFuture<T> {
-    return transformer.trans(scope, block)
+    return transformer.trans(scope ?: `$CoroutineScope4J$`, block)
 }
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,5 +8,5 @@ include(":runtime:suspend-transform-runtime")
 
 include(":plugins:suspend-transform-plugin-gradle")
 
-//include(":suspend-transform-plugin-sample")
+include(":suspend-transform-plugin-sample")
 // include(":plugins:ide:suspend-transform-plugin-idea")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,5 +8,5 @@ include(":runtime:suspend-transform-runtime")
 
 include(":plugins:suspend-transform-plugin-gradle")
 
-include(":suspend-transform-plugin-sample")
+//include(":suspend-transform-plugin-sample")
 // include(":plugins:ide:suspend-transform-plugin-idea")

--- a/suspend-transform-plugin-sample/build.gradle.kts
+++ b/suspend-transform-plugin-sample/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     // id(project(":suspend-transform-plugin-gradle"))
 }
 
+
  buildscript {
      this@buildscript.repositories {
          mavenLocal()
@@ -15,7 +16,7 @@ plugins {
      }
      dependencies {
          //this.implementation()
-         classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:0.3.2")
+         classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:0.4.0")
      }
  }
 
@@ -24,9 +25,10 @@ plugins {
 //    sourceCompatibility = "11"
 //    targetCompatibility = "11"
 //}
-//withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-//    kotlinOptions.jvmTarget = "11"
-//}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions.freeCompilerArgs += "-Xjvm-default=all"
+}
 
 repositories {
     mavenLocal()
@@ -36,9 +38,10 @@ apply(plugin = "love.forte.plugin.suspend-transform")
 
 dependencies {
     api(kotlin("stdlib"))
-//    api("love.forte.plugin.suspend-transform:suspend-transform-runtime:0.3.2")
-//    api("love.forte.plugin.suspend-transform:suspend-transform-annotation:0.3.2")
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0")
+//    val pluginVersion = "0.4.0"
+//    api("love.forte.plugin.suspend-transform:suspend-transform-runtime:$pluginVersion")
+//    api("love.forte.plugin.suspend-transform:suspend-transform-annotation:$pluginVersion")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 }
 
 extensions.getByType<SuspendTransformGradleExtension>().apply {

--- a/suspend-transform-plugin-sample/src/main/kotlin/love/forte/plugin/suspendtrans/sample/ForteScarlet.kt
+++ b/suspend-transform-plugin-sample/src/main/kotlin/love/forte/plugin/suspendtrans/sample/ForteScarlet.kt
@@ -3,12 +3,14 @@ package love.forte.plugin.suspendtrans.sample
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 
 abstract class IForteScarlet {
     @JvmAsync
+    @JvmBlocking
     abstract suspend fun stringToInt(value: String): Int
 }
 
@@ -22,6 +24,7 @@ class ForteScarlet : CoroutineScope, IForteScarlet() {
         get() = EmptyCoroutineContext
 
     @JvmAsync
+    @JvmBlocking
     override suspend fun stringToInt(value: String): Int {
         delay(5)
         return value.toInt()

--- a/suspend-transform-plugin-sample/src/main/kotlin/love/forte/plugin/suspendtrans/sample/ForteScarlet.kt
+++ b/suspend-transform-plugin-sample/src/main/kotlin/love/forte/plugin/suspendtrans/sample/ForteScarlet.kt
@@ -7,18 +7,30 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 
+abstract class IForteScarlet {
+    @JvmAsync
+    abstract suspend fun stringToInt(value: String): Int
+}
+
+
 /**
  *
  * @author ForteScarlet
  */
-class ForteScarlet : CoroutineScope {
+class ForteScarlet : CoroutineScope, IForteScarlet() {
     override val coroutineContext: CoroutineContext
         get() = EmptyCoroutineContext
 
     @JvmAsync
-    suspend fun stringToInt(value: String): Int {
+    override suspend fun stringToInt(value: String): Int {
         delay(5)
         return value.toInt()
     }
+
+    //    @JvmAsync
+//    suspend fun stringToInt(value: String): Int {
+//        delay(5)
+//        return value.toInt()
+//    }
 
 }


### PR DESCRIPTION
当转换函数中存在 `CoroutineScope` 类型的参数时，会根据当前 receiver **尝试** 将其填充至此参数。

e.g.

transform function:

```kotlin
public fun <T> runInAsync(
    block: suspend () -> T,
    // A `CoroutineScope` parameter
    scope: CoroutineScope = DefaultCoroutineScope
): CompletableFuture<T> {
    return scope.future { block() }
}
```

source: 

```kotlin
abstract class Foo : CoroutineScope {
    @JvmAsync
    abstract suspend fun stringToInt(value: String): Int
} 
```

generated: 

```kotlin
abstract class Foo : CoroutineScope {
    @JvmAsync
    abstract suspend fun stringToInt(value: String): Int

    
    fun stringToIntAsync(value: String): Int = 
        runInAsync({ stringToInt(value) }, this /* Use 'this' as CoroutineScope */)

}
```

and nullable support (推荐) .

transform function:

```kotlin
public fun <T> runInAsync(
    block: suspend () -> T,
    // A `CoroutineScope` parameter
    scope: CoroutineScope? = null
): CompletableFuture<T> {
    return(scope ?: DefaultCoroutineScope).future { block() }
}
```


source: 

```kotlin
abstract class Foo { // not `CoroutineScope`
    @JvmAsync
    abstract suspend fun stringToInt(value: String): Int
} 
```

generated: 

```kotlin
abstract class Foo {
    @JvmAsync
    abstract suspend fun stringToInt(value: String): Int

    
    fun stringToIntAsync(value: String): Int = 
        runInAsync({ stringToInt(value) }, this as? CoroutineScope /* Try to use 'this' as CoroutineScope */)

}
```

第二种方式在接口/抽象类中使用会更加有效，因为这可以使其实现的子类不再必须显示重新标记转化函数即可享受到 `CoroutineScope` 的转化

