### PR TITLE
Remove duplicate of IR nodes inside the body

### DIFF
--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/ir/SuspendTransformTransformer.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/ir/SuspendTransformTransformer.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrBody
@@ -241,21 +242,17 @@ private fun generateTransformBodyForFunctionLambda(
         parameter.defaultValue = originFunctionValueParameter.defaultValue
     }
 
-
     return context.createIrBuilder(function.symbol).irBlockBody {
         val suspendLambdaFunc = context.createSuspendLambdaFunctionWithCoroutineScope(
             originFunction = originFunction,
             function = function,
             this
-        ).also { +it }
+        )
 
         val lambdaType = context.symbols.suspendFunctionN(0).typeWith(suspendLambdaFunc.returnType)
 
-        val ex = IrFunctionExpressionImpl(-1, -1, lambdaType, suspendLambdaFunc, IrStatementOrigin.LAMBDA)
-        +ex
-
         +irReturn(irCall(transformTargetFunctionCall).apply {
-            putValueArgument(0, ex)
+            putValueArgument(0, IrFunctionExpressionImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, lambdaType, suspendLambdaFunc, IrStatementOrigin.LAMBDA))
             // argument: 1, if is CoroutineScope, and this is CoroutineScope.
             val owner = transformTargetFunctionCall.owner
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/IrFunctionUtils.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/IrFunctionUtils.kt
@@ -10,9 +10,7 @@ import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
-import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetFieldImpl
-import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.typeOrNull
@@ -59,7 +57,7 @@ fun IrPluginContext.createSuspendLambdaWithCoroutineScope(
     lambdaType: IrSimpleType,
     originFunction: IrFunction,
 ): IrClass {
-    return IrFactoryImpl.buildClass {
+    return irFactory.buildClass {
         name = SpecialNames.NO_NAME_PROVIDED
         kind = ClassKind.CLASS
         /*
@@ -149,35 +147,15 @@ fun IrPluginContext.createSuspendLambdaFunctionWithCoroutineScope(
     function: IrFunction,
     blockBodyBuilder: IrBlockBodyBuilder
 ): IrSimpleFunction {
-    val func = IrFunctionImpl(
-        startOffset = -1,
-        endOffset = -1,
-        origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA,
-        name = SpecialNames.NO_NAME_PROVIDED,
-        visibility = DescriptorVisibilities.LOCAL,
-        isInline = false,
-        isExpect = false,
-        returnType = function.returnType,
-        modality = Modality.FINAL,
-        symbol = IrSimpleFunctionSymbolImpl(),
-        isSuspend = true,
-        isTailrec = false,
-        isOperator = false,
-        isInfix = false,
-        isExternal = false,
-    )
-
-//    val func1 = IrFactoryImpl.buildFun {
-//        name = SpecialNames.NO_NAME_PROVIDED
-//        visibility = DescriptorVisibilities.LOCAL
-//        isSuspend = true
-//        returnType = function.returnType
-//    }
-
-    with(func) {
+    return irFactory.buildFun {
+        origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
+        name = SpecialNames.NO_NAME_PROVIDED
+        visibility = DescriptorVisibilities.LOCAL
+        returnType = function.returnType
+        modality = Modality.FINAL
+        isSuspend = true
+    }.apply {
         parent = function
-//        origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
-
         body = createIrBuilder(symbol).run {
             // don't use expr body, coroutine codegen can't generate for it.
             irBlockBody {
@@ -198,8 +176,6 @@ fun IrPluginContext.createSuspendLambdaFunctionWithCoroutineScope(
             }
         }
     }
-
-    return func
 }
 
 fun IrFunction.paramsAndReceiversAsParamsList(): List<IrValueParameter> {


### PR DESCRIPTION
I found the problem you had with the local lambda creation.
You used `+expr`, so, every node was added at least twice, and while the KLIB deserializer tried to create a function, it meat two variants of function that refer to the same symbol (this is an illegal state of the IR in Kotlin).
I've fixed all the things, so it compiles both for JVM and JS