### PR TITLE
清理部分遗留的测试代码；修改JS runInAsync 内默认调度器

### DIFF
--- a/runtime/suspend-transform-runtime/src/jsMain/kotlin/love.forte.plugin.suspendtrans/runtime/RunInSuspendJs.kt
+++ b/runtime/suspend-transform-runtime/src/jsMain/kotlin/love.forte.plugin.suspendtrans/runtime/RunInSuspendJs.kt
@@ -12,13 +12,10 @@ private val CoroutineScope4Js: CoroutineScope = CoroutineScope(CoroutineContext4
 
 
 @Suppress("FunctionName")
-//@Deprecated("Just for generate.", level = DeprecationLevel.HIDDEN)
+@Deprecated("Just for compile plugin.", level = DeprecationLevel.HIDDEN)
 public fun <T, F : suspend () -> T> `$runInAsync$`(
     block: F,
     scope: CoroutineScope? = null
 ): Promise<T> {
-    println("block: $block")
-    println("block.asDynamic().invoke: " + block.asDynamic().invoke)
-    println("block::class: " + block::class)
     return (scope ?: CoroutineScope4Js).promise { block.invoke() }
 }

--- a/runtime/suspend-transform-runtime/src/jsMain/kotlin/love.forte.plugin.suspendtrans/runtime/RunInSuspendJs.kt
+++ b/runtime/suspend-transform-runtime/src/jsMain/kotlin/love.forte.plugin.suspendtrans/runtime/RunInSuspendJs.kt
@@ -1,12 +1,12 @@
 package love.forte.plugin.suspendtrans.runtime
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.promise
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.js.Promise
 
-private val CoroutineContext4Js: CoroutineContext = EmptyCoroutineContext
+private val CoroutineContext4Js: CoroutineContext = Dispatchers.Default
 
 private val CoroutineScope4Js: CoroutineScope = CoroutineScope(CoroutineContext4Js)
 


### PR DESCRIPTION
JS runtime 里的 `$runInAsync$` 默认的调度器修改为 `Dispatchers.Default`