### PR TITLE
Support for configuring `includeProperty` in the IncludeAnnotation

### DIFF
--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -1,6 +1,5 @@
 import love.forte.gradle.common.core.project.ProjectDetail
 import love.forte.gradle.common.core.project.Version
-import love.forte.gradle.common.core.project.minus
 import love.forte.gradle.common.core.project.version
 
 object IProject : ProjectDetail() {
@@ -9,7 +8,7 @@ object IProject : ProjectDetail() {
     const val DESCRIPTION = "Generate platform-compatible functions for Kotlin suspend functions"
     const val HOMEPAGE = "https://github.com/ForteScarlet/kotlin-suspend-transform-compiler-plugin"
 
-    override val version: Version = version(0, 9, 0) - version("beta1")
+    override val version: Version = version(0, 9, 0)
 
     override val homepage: String get() = HOMEPAGE
 

--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -9,7 +9,7 @@ object IProject : ProjectDetail() {
     const val DESCRIPTION = "Generate platform-compatible functions for Kotlin suspend functions"
     const val HOMEPAGE = "https://github.com/ForteScarlet/kotlin-suspend-transform-compiler-plugin"
 
-    override val version: Version = version(0, 8, 0) - version("beta1")
+    override val version: Version = version(0, 9, 0) - version("beta1")
 
     override val homepage: String get() = HOMEPAGE
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/SuspendTransformConfiguration.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/SuspendTransformConfiguration.kt
@@ -95,7 +95,7 @@ data class Transformer(
     /**
      * 如果是生成属性的话，是否复制源函数上的注解到新的属性上
      *
-     * @since 0.8.0
+     * @since 0.9.0
      */
     var copyAnnotationsToSyntheticProperty: Boolean = false
 }
@@ -142,6 +142,8 @@ data class IncludeAnnotation(
 ) {
     /**
      * 如果是追加，是否追加到property上
+     *
+     * @since 0.9.0
      */
     var includeProperty: Boolean = false
 }
@@ -311,7 +313,11 @@ open class SuspendTransformConfiguration {
             originFunctionIncludeAnnotations = listOf(),
             copyAnnotationsToSyntheticFunction = true,
             copyAnnotationExcludes = listOf(jsAsyncAnnotationInfo.classInfo),
-            syntheticFunctionIncludeAnnotations = listOf(IncludeAnnotation(jsApi4JsAnnotationInfo))
+            syntheticFunctionIncludeAnnotations = listOf(
+                IncludeAnnotation(jsApi4JsAnnotationInfo).apply {
+                    includeProperty = true
+                }
+            )
         )
         //endregion
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/SuspendTransformConfiguration.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/SuspendTransformConfiguration.kt
@@ -77,12 +77,13 @@ data class Transformer(
     val originFunctionIncludeAnnotations: List<IncludeAnnotation>,
 
     /**
-     * 需要在生成出来的函数上追截的注解信息。（不需要指定 `@Generated`）
+     * 需要在生成出来的函数上追加的注解信息。（不需要指定 `@Generated`）
      */
     val syntheticFunctionIncludeAnnotations: List<IncludeAnnotation>,
 
     /**
      * 是否复制源函数上的注解到新的函数上。
+     * 如果生成的是属性类型，则表示是否复制到 `getter` 上。
      */
     val copyAnnotationsToSyntheticFunction: Boolean,
 
@@ -90,7 +91,14 @@ data class Transformer(
      * 复制原函数上注解时需要排除掉的注解。
      */
     val copyAnnotationExcludes: List<ClassInfo>
-)
+) {
+    /**
+     * 如果是生成属性的话，是否复制源函数上的注解到新的属性上
+     *
+     * @since 0.8.0
+     */
+    var copyAnnotationsToSyntheticProperty: Boolean = false
+}
 
 /**
  * 用于标记的注解信息.
@@ -131,7 +139,12 @@ data class MarkAnnotation @JvmOverloads constructor(
 @Serializable
 data class IncludeAnnotation(
     val classInfo: ClassInfo, val repeatable: Boolean = false
-)
+) {
+    /**
+     * 如果是追加，是否追加到property上
+     */
+    var includeProperty: Boolean = false
+}
 
 /**
  *
@@ -234,7 +247,10 @@ open class SuspendTransformConfiguration {
             originFunctionIncludeAnnotations = listOf(IncludeAnnotation(jvmSyntheticClassInfo)),
             copyAnnotationsToSyntheticFunction = true,
             copyAnnotationExcludes = listOf(jvmSyntheticClassInfo, jvmBlockingAnnotationInfo.classInfo),
-            syntheticFunctionIncludeAnnotations = listOf(IncludeAnnotation(jvmApi4JAnnotationClassInfo))
+            syntheticFunctionIncludeAnnotations = listOf(
+                IncludeAnnotation(jvmApi4JAnnotationClassInfo)
+                    .apply { includeProperty = true }
+            )
         )
         //endregion
 
@@ -261,7 +277,11 @@ open class SuspendTransformConfiguration {
             originFunctionIncludeAnnotations = listOf(IncludeAnnotation(jvmSyntheticClassInfo)),
             copyAnnotationsToSyntheticFunction = true,
             copyAnnotationExcludes = listOf(jvmSyntheticClassInfo, jvmAsyncAnnotationInfo.classInfo),
-            syntheticFunctionIncludeAnnotations = listOf(IncludeAnnotation(jvmApi4JAnnotationClassInfo))
+            syntheticFunctionIncludeAnnotations = listOf(
+                IncludeAnnotation(jvmApi4JAnnotationClassInfo).apply {
+                    includeProperty = true
+                }
+            )
         )
         //endregion
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/symbol/AbstractSuspendTransformFunctionDescriptor.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/symbol/AbstractSuspendTransformFunctionDescriptor.kt
@@ -28,7 +28,7 @@ sealed class AbstractSuspendTransformFunctionDescriptor(
     private val originFunction: SimpleFunctionDescriptor,
     functionName: Name,
     annotations: Annotations,
-    internal val propertyAnnotations: Annotations,
+    val propertyAnnotations: Annotations,
     private val userData: SuspendTransformUserData,
     val transformer: Transformer
 ) : SimpleFunctionDescriptorImpl(
@@ -92,7 +92,7 @@ sealed class AbstractSuspendTransformFunctionDescriptor(
         return SimpleSuspendTransformPropertyDescriptor(
             classDescriptor,
             this,
-            annotations,
+            propertyAnnotations,
         )
     }
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/CopyAnnotationUtils.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/CopyAnnotationUtils.kt
@@ -5,15 +5,17 @@ import org.jetbrains.kotlin.name.ClassId
 
 data class CopyAnnotationsData(
     val copyFunction: Boolean,
+    val copyProperty: Boolean,
     val excludes: List<ClassId>,
     val includes: List<IncludeAnnotationInfo>
 )
 
 data class IncludeAnnotationInfo(
     val classId: ClassId,
-    val repeatable: Boolean
+    val repeatable: Boolean,
+    val includeProperty: Boolean,
 )
 
-fun IncludeAnnotation.toInfo(): love.forte.plugin.suspendtrans.utils.IncludeAnnotationInfo {
-    return IncludeAnnotationInfo(classInfo.toClassId(), repeatable)
+fun IncludeAnnotation.toInfo(): IncludeAnnotationInfo {
+    return IncludeAnnotationInfo(classInfo.toClassId(), repeatable, includeProperty)
 }

--- a/samples/sample-jvm/build.gradle.kts
+++ b/samples/sample-jvm/build.gradle.kts
@@ -1,4 +1,5 @@
 import love.forte.plugin.suspendtrans.gradle.SuspendTransformGradleExtension
+import org.jetbrains.kotlin.js.translate.context.Namer.kotlin
 
 plugins {
     `java-library`
@@ -16,7 +17,7 @@ buildscript {
     }
     dependencies {
         //this.implementation()
-        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:0.8.0-beta1")
+        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:0.9.0-beta1")
     }
 }
 


### PR DESCRIPTION
**Before**

build:
```kotlin
useJvmDefault()
// or 

addJvmTransformer(
  Transformer(
    ...,
    syntheticFunctionIncludeAnnotations = listOf(
                IncludeAnnotation(jvmApi4JAnnotationClassInfo)
            )
  )
)
```

Then the source:

```kotlin
class Foo {
    @JvmBlocking(asProperty = true)
    suspend value(): Int = 1
}
```

the compiled:
```kotlin
class Foo {
    @JvmSynthetic
    suspend value(): Int = 1

    val valueBlocking: Int
        @Api4J // Problem: RequiresOptIn doesn't work on getters.
        get() = runInBlocking { value() }
}
```

**After**

build:
```kotlin
useJvmDefault()
// or 

addJvmTransformer(
  Transformer(
    ...,
    syntheticFunctionIncludeAnnotations = listOf(
                IncludeAnnotation(jvmApi4JAnnotationClassInfo).apply {
                    includeProperty = true 
                    // 👆 support for including to the property
                }
            )
  )
)
```

Then the source:

```kotlin
class Foo {
    @JvmBlocking(asProperty = true)
    suspend value(): Int = 1
}
```

the compiled:
```kotlin
class Foo {
    @JvmSynthetic
    suspend value(): Int = 1

    @Api4J // Included to this property
    val valueBlocking: Int
        @Api4J
        get() = runInBlocking { value() }
}
```

