### PR TITLE
optimize: `override` for synthetic functions

### DIFF
--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -11,7 +11,7 @@ object IProject : ProjectDetail() {
 
     // Remember the libs.versions.toml!
     val ktVersion = "2.1.0-Beta1"
-    val pluginVersion = "0.9.2"
+    val pluginVersion = "0.9.3"
 
     override val version: String = "$ktVersion-$pluginVersion"
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/fir/SuspendTransformFirTransformer.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/fir/SuspendTransformFirTransformer.kt
@@ -95,6 +95,13 @@ class SuspendTransformFirTransformer(
         return names
     }
 
+    private val scope = ScopeSession()
+    private val holder = SessionHolderImpl(session, scope)
+    private val checkContext = MutableCheckerContext(
+        holder,
+        ReturnTypeCalculatorForFullBodyResolve.Default,
+    )
+
     @OptIn(SymbolInternals::class)
     override fun generateFunctions(
         callableId: CallableId,
@@ -107,19 +114,13 @@ class SuspendTransformFirTransformer(
 
         val funList = mutableListOf<FirNamedFunctionSymbol>()
 
-        val scope = ScopeSession()
-        val holder = SessionHolderImpl(session, scope)
-        val checkContext = MutableCheckerContext(
-            holder,
-            ReturnTypeCalculatorForFullBodyResolve.Default,
-        )
-
         funcMap.forEach { (func, funData) ->
-            // Check the overridden for isOverride based on source function (func) 's overridden
-            val isOverride = checkSyntheticFunctionIsOverrideBasedOnSourceFunction(funData, func, checkContext)
 
             val annotationData = funData.annotationData
             if (!annotationData.asProperty) {
+                // Check the overridden for isOverride based on source function (func) 's overridden
+                val isOverride = checkSyntheticFunctionIsOverrideBasedOnSourceFunction(funData, func, checkContext)
+
                 // generate
 
                 val originFunc = func.fir
@@ -198,19 +199,11 @@ class SuspendTransformFirTransformer(
 
         val propList = mutableListOf<FirPropertySymbol>()
 
-        val scope = ScopeSession()
-        val holder = SessionHolderImpl(session, scope)
-        val checkContext = MutableCheckerContext(
-            holder,
-            ReturnTypeCalculatorForFullBodyResolve.Contract,
-        )
-
         funcMap.forEach { (func, funData) ->
-
-            val isOverride = checkSyntheticFunctionIsOverrideBasedOnSourceFunction(funData, func, checkContext)
-
             val annotationData = funData.annotationData
             if (annotationData.asProperty) {
+                val isOverride = checkSyntheticFunctionIsOverrideBasedOnSourceFunction(funData, func, checkContext)
+
                 // generate
                 val original = func.fir
 

--- a/compiler/suspend-transform-plugin/src/test-gen/love/forte/plugin/suspendtrans/runners/CodeGenTestRunnerGenerated.java
+++ b/compiler/suspend-transform-plugin/src/test-gen/love/forte/plugin/suspendtrans/runners/CodeGenTestRunnerGenerated.java
@@ -49,4 +49,16 @@ public class CodeGenTestRunnerGenerated extends AbstractCodeGenTestRunner {
   public void testOpt() {
     runTest("src/testData/codegen/opt.kt");
   }
+
+  @Test
+  @TestMetadata("implOverriden.kt")
+  public void testImplOverriden() {
+    runTest("src/testData/codegen/implOverriden.kt");
+  }
+
+  @Test
+  @TestMetadata("implOverridenGeneric.kt")
+  public void testImplOverridenGeneric() {
+    runTest("src/testData/codegen/implOverridenGeneric.kt");
+  }
 }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.asm.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.asm.txt
@@ -1,0 +1,297 @@
+public abstract interface FooInterface1 : java/lang/Object {
+    public abstract java.lang.Object data(kotlin.coroutines.Continuation p0)
+
+    public abstract java.lang.Object data2(int p0, kotlin.coroutines.Continuation p1)
+
+    public abstract java.lang.Object data3(int p0, kotlin.coroutines.Continuation p1)
+}
+
+final class FooInterface1Impl$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $value
+
+    int label
+
+    final FooInterface1Impl this$0
+
+    void <init>(FooInterface1Impl $receiver, int $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface1Impl$data3Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $this_data3Blocking
+
+    int label
+
+    final FooInterface1Impl this$0
+
+    void <init>(FooInterface1Impl $receiver, int $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface1Impl$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface1Impl this$0
+
+    void <init>(FooInterface1Impl $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class FooInterface1Impl : java/lang/Object, FooInterface1 {
+    public void <init>()
+
+    public java.lang.Object data(kotlin.coroutines.Continuation $completion)
+
+    public java.lang.Object data2(int value, kotlin.coroutines.Continuation $completion)
+
+    public java.lang.String data2Blocking(int value)
+
+    public java.lang.Object data3(int $this$data3, kotlin.coroutines.Continuation $completion)
+
+    public java.lang.String data3Blocking(int $this$data3Blocking)
+
+    public java.lang.String dataBlocking()
+}
+
+public final class FooInterface2$DefaultImpls : java/lang/Object {
+    public static java.lang.String data2Blocking(FooInterface2 $this, int value)
+
+    public static java.lang.String data3Blocking(FooInterface2 $this, int $receiver)
+
+    public static java.lang.String dataBlocking(FooInterface2 $this)
+}
+
+public abstract interface FooInterface2 : java/lang/Object {
+    public abstract java.lang.Object data(kotlin.coroutines.Continuation p0)
+
+    public abstract java.lang.Object data2(int p0, kotlin.coroutines.Continuation p1)
+
+    public abstract java.lang.String data2Blocking(int p0)
+
+    public abstract java.lang.Object data3(int p0, kotlin.coroutines.Continuation p1)
+
+    public abstract java.lang.String data3Blocking(int p0)
+
+    public abstract java.lang.String dataBlocking()
+}
+
+final class FooInterface2Impl$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $value
+
+    int label
+
+    final FooInterface2Impl this$0
+
+    void <init>(FooInterface2Impl $receiver, int $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface2Impl$data3Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $this_data3Blocking
+
+    int label
+
+    final FooInterface2Impl this$0
+
+    void <init>(FooInterface2Impl $receiver, int $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface2Impl$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface2Impl this$0
+
+    void <init>(FooInterface2Impl $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class FooInterface2Impl : java/lang/Object, FooInterface2 {
+    public void <init>()
+
+    public java.lang.Object data(kotlin.coroutines.Continuation $completion)
+
+    public java.lang.Object data2(int value, kotlin.coroutines.Continuation $completion)
+
+    public java.lang.String data2Blocking(int value)
+
+    public java.lang.Object data3(int $this$data3, kotlin.coroutines.Continuation $completion)
+
+    public java.lang.String data3Blocking(int $this$data3Blocking)
+
+    public java.lang.String dataBlocking()
+}
+
+public final class FooInterface3$DefaultImpls : java/lang/Object {
+    public static java.lang.String getDataBlocking(FooInterface3 $this)
+}
+
+public abstract interface FooInterface3 : java/lang/Object {
+    public abstract java.lang.Object data(kotlin.coroutines.Continuation p0)
+
+    public abstract java.lang.String getDataBlocking()
+}
+
+final class FooInterface3Impl$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface3Impl this$0
+
+    void <init>(FooInterface3Impl $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class FooInterface3Impl : java/lang/Object, FooInterface3 {
+    public void <init>()
+
+    public java.lang.Object data(kotlin.coroutines.Continuation $completion)
+
+    public java.lang.String getDataBlocking()
+
+    public static void getDataBlocking$annotations()
+}
+
+public final class FooInterface4$DefaultImpls : java/lang/Object {
+    public static java.lang.String data2Blocking(FooInterface4 $this, int value)
+
+    public static java.lang.String dataBlocking(FooInterface4 $this)
+}
+
+final class FooInterface4$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $value
+
+    int label
+
+    final FooInterface4 this$0
+
+    void <init>(FooInterface4 $receiver, int $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface4$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface4 this$0
+
+    void <init>(FooInterface4 $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public abstract interface FooInterface4 : java/lang/Object {
+    public abstract java.lang.Object data(kotlin.coroutines.Continuation p0)
+
+    public abstract java.lang.Object data2(int p0, kotlin.coroutines.Continuation p1)
+
+    public abstract java.lang.String data2Blocking(int p0)
+
+    public abstract java.lang.String dataBlocking()
+}
+
+final class FooInterface4Impl$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $value
+
+    int label
+
+    final FooInterface4Impl this$0
+
+    void <init>(FooInterface4Impl $receiver, int $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface4Impl$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface4Impl this$0
+
+    void <init>(FooInterface4Impl $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class FooInterface4Impl : java/lang/Object, FooInterface4 {
+    public void <init>()
+
+    public java.lang.Object data(kotlin.coroutines.Continuation $completion)
+
+    public java.lang.Object data2(int value, kotlin.coroutines.Continuation $completion)
+
+    public java.lang.String data2Blocking(int value)
+
+    public java.lang.String dataBlocking()
+}

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.fir.ir.txt
@@ -1,0 +1,469 @@
+FILE fqName:<root> fileName:/Main.kt
+  CLASS CLASS name:FooInterface1Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface1]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface1Impl
+    CONSTRUCTOR visibility:public <> () returnType:<root>.FooInterface1Impl [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FooInterface1Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface1]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl, value:kotlin.Int) returnType:kotlin.String
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking (value: kotlin.Int): kotlin.String declared in <root>.FooInterface1Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface1Impl.data2Blocking'
+                    CALL 'public open fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface1Impl' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface1Impl declared in <root>.FooInterface1Impl.data2Blocking' type=<root>.FooInterface1Impl origin=null
+                      value: GET_VAR 'value: kotlin.Int declared in <root>.FooInterface1Impl.data2Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl, $receiver:kotlin.Int) returnType:kotlin.String
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): kotlin.String declared in <root>.FooInterface1Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface1Impl.data3Blocking'
+                    CALL 'public open fun data3 (): kotlin.String declared in <root>.FooInterface1Impl' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface1Impl declared in <root>.FooInterface1Impl.data3Blocking' type=<root>.FooInterface1Impl origin=null
+                      $receiver: GET_VAR '<this>: kotlin.Int declared in <root>.FooInterface1Impl.data3Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl) returnType:kotlin.String
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): kotlin.String declared in <root>.FooInterface1Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface1Impl.dataBlocking'
+                    CALL 'public open fun data (): kotlin.String declared in <root>.FooInterface1Impl' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface1Impl declared in <root>.FooInterface1Impl.dataBlocking' type=<root>.FooInterface1Impl origin=null
+    FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data (): kotlin.String declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data (): kotlin.String declared in <root>.FooInterface1Impl'
+          CONST String type=kotlin.String value=""
+    FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl, value:kotlin.Int) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface1Impl'
+          CONST String type=kotlin.String value=""
+    FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl, $receiver:kotlin.Int) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data3 (): kotlin.String declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3 (): kotlin.String declared in <root>.FooInterface1Impl'
+          CONST String type=kotlin.String value=""
+  CLASS CLASS name:FooInterface2Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface2]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface2Impl
+    CONSTRUCTOR visibility:public <> () returnType:<root>.FooInterface2Impl [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FooInterface2Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface2]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl, value:kotlin.Int) returnType:kotlin.String
+      annotations:
+        Api4J
+      overridden:
+        public open fun data2Blocking (value: kotlin.Int): kotlin.String declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking (value: kotlin.Int): kotlin.String declared in <root>.FooInterface2Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface2Impl.data2Blocking'
+                    CALL 'public open fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface2Impl' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface2Impl declared in <root>.FooInterface2Impl.data2Blocking' type=<root>.FooInterface2Impl origin=null
+                      value: GET_VAR 'value: kotlin.Int declared in <root>.FooInterface2Impl.data2Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl, $receiver:kotlin.Int) returnType:kotlin.String
+      annotations:
+        Api4J
+      overridden:
+        public open fun data3Blocking (): kotlin.String declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): kotlin.String declared in <root>.FooInterface2Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface2Impl.data3Blocking'
+                    CALL 'public open fun data3 (): kotlin.String declared in <root>.FooInterface2Impl' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface2Impl declared in <root>.FooInterface2Impl.data3Blocking' type=<root>.FooInterface2Impl origin=null
+                      $receiver: GET_VAR '<this>: kotlin.Int declared in <root>.FooInterface2Impl.data3Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl) returnType:kotlin.String
+      annotations:
+        Api4J
+      overridden:
+        public open fun dataBlocking (): kotlin.String declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): kotlin.String declared in <root>.FooInterface2Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface2Impl.dataBlocking'
+                    CALL 'public open fun data (): kotlin.String declared in <root>.FooInterface2Impl' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface2Impl declared in <root>.FooInterface2Impl.dataBlocking' type=<root>.FooInterface2Impl origin=null
+    FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data (): kotlin.String declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data (): kotlin.String declared in <root>.FooInterface2Impl'
+          CONST String type=kotlin.String value=""
+    FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl, value:kotlin.Int) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface2Impl'
+          CONST String type=kotlin.String value=""
+    FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl, $receiver:kotlin.Int) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data3 (): kotlin.String declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3 (): kotlin.String declared in <root>.FooInterface2Impl'
+          CONST String type=kotlin.String value=""
+  CLASS CLASS name:FooInterface3Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface3]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface3Impl
+    CONSTRUCTOR visibility:public <> () returnType:<root>.FooInterface3Impl [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FooInterface3Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface3]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = true)
+        JvmSynthetic
+      overridden:
+        public abstract fun data (): kotlin.String declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data (): kotlin.String declared in <root>.FooInterface3Impl'
+          CONST String type=kotlin.String value=""
+    PROPERTY GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN [val]
+      annotations:
+        Api4J
+      overridden:
+        public open dataBlocking: kotlin.String declared in <root>.FooInterface3
+      FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:<get-dataBlocking> visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl) returnType:kotlin.String
+        annotations:
+          Api4J
+        correspondingProperty: PROPERTY GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN [val]
+        overridden:
+          public open fun <get-dataBlocking> (): kotlin.String declared in <root>.FooInterface3
+        $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3Impl
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun <get-dataBlocking> (): kotlin.String declared in <root>.FooInterface3Impl'
+            CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+              <T>: <none>
+              block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+                FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                  BLOCK_BODY
+                    RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface3Impl.<get-dataBlocking>'
+                      CALL 'public open fun data (): kotlin.String declared in <root>.FooInterface3Impl' type=kotlin.String origin=null
+                        $this: GET_VAR '<this>: <root>.FooInterface3Impl declared in <root>.FooInterface3Impl.<get-dataBlocking>' type=<root>.FooInterface3Impl origin=null
+  CLASS CLASS name:FooInterface4Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface4]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface4Impl
+    CONSTRUCTOR visibility:public <> () returnType:<root>.FooInterface4Impl [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FooInterface4Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface4]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl, value:kotlin.Int) returnType:kotlin.String
+      annotations:
+        Api4J
+      overridden:
+        public open fun data2Blocking (value: kotlin.Int): kotlin.String declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking (value: kotlin.Int): kotlin.String declared in <root>.FooInterface4Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface4Impl.data2Blocking'
+                    CALL 'public open fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface4Impl' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4Impl declared in <root>.FooInterface4Impl.data2Blocking' type=<root>.FooInterface4Impl origin=null
+                      value: GET_VAR 'value: kotlin.Int declared in <root>.FooInterface4Impl.data2Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl) returnType:kotlin.String
+      annotations:
+        Api4J
+      overridden:
+        public open fun dataBlocking (): kotlin.String declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): kotlin.String declared in <root>.FooInterface4Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface4Impl.dataBlocking'
+                    CALL 'public open fun data (): kotlin.String declared in <root>.FooInterface4Impl' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4Impl declared in <root>.FooInterface4Impl.dataBlocking' type=<root>.FooInterface4Impl origin=null
+    FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data (): kotlin.String declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data (): kotlin.String declared in <root>.FooInterface4Impl'
+          CONST String type=kotlin.String value=""
+    FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl, value:kotlin.Int) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface4Impl'
+          CONST String type=kotlin.String value=""
+  CLASS INTERFACE name:FooInterface1 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface1
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface1) returnType:kotlin.String [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1
+    FUN name:data2 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface1, value:kotlin.Int) returnType:kotlin.String [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+    FUN name:data3 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface1, $receiver:kotlin.Int) returnType:kotlin.String [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+  CLASS INTERFACE name:FooInterface2 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface2
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface2) returnType:kotlin.String [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2
+    FUN name:data2 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface2, value:kotlin.Int) returnType:kotlin.String [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+    FUN name:data2Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2, value:kotlin.Int) returnType:kotlin.String
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking (value: kotlin.Int): kotlin.String declared in <root>.FooInterface2'
+          CONST String type=kotlin.String value=""
+    FUN name:data3 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface2, $receiver:kotlin.Int) returnType:kotlin.String [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+    FUN name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2, $receiver:kotlin.Int) returnType:kotlin.String
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): kotlin.String declared in <root>.FooInterface2'
+          CONST String type=kotlin.String value=""
+    FUN name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2) returnType:kotlin.String
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): kotlin.String declared in <root>.FooInterface2'
+          CONST String type=kotlin.String value=""
+  CLASS INTERFACE name:FooInterface3 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface3
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface3) returnType:kotlin.String [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3
+    PROPERTY name:dataBlocking visibility:public modality:OPEN [val]
+      FUN name:<get-dataBlocking> visibility:public modality:OPEN <> ($this:<root>.FooInterface3) returnType:kotlin.String
+        correspondingProperty: PROPERTY name:dataBlocking visibility:public modality:OPEN [val]
+        $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun <get-dataBlocking> (): kotlin.String declared in <root>.FooInterface3'
+            CONST String type=kotlin.String value=""
+  CLASS INTERFACE name:FooInterface4 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface4
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4, value:kotlin.Int) returnType:kotlin.String
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking (value: kotlin.Int): kotlin.String declared in <root>.FooInterface4'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface4.data2Blocking'
+                    CALL 'public abstract fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface4' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4 declared in <root>.FooInterface4.data2Blocking' type=<root>.FooInterface4 origin=null
+                      value: GET_VAR 'value: kotlin.Int declared in <root>.FooInterface4.data2Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4) returnType:kotlin.String
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): kotlin.String declared in <root>.FooInterface4'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.String [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.String declared in <root>.FooInterface4.dataBlocking'
+                    CALL 'public abstract fun data (): kotlin.String declared in <root>.FooInterface4' type=kotlin.String origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4 declared in <root>.FooInterface4.dataBlocking' type=<root>.FooInterface4 origin=null
+    FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4
+    FUN name:data2 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4, value:kotlin.Int) returnType:kotlin.String [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4
+      VALUE_PARAMETER name:value index:0 type:kotlin.Int

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.fir.txt
@@ -1,0 +1,127 @@
+FILE: Main.kt
+    public abstract interface FooInterface1 : R|kotlin/Any| {
+        public abstract suspend fun data(): R|kotlin/String|
+
+        public abstract suspend fun data2(value: R|kotlin/Int|): R|kotlin/String|
+
+        public abstract suspend fun R|kotlin/Int|.data3(): R|kotlin/String|
+
+    }
+    public final class FooInterface1Impl : R|FooInterface1| {
+        public constructor(): R|FooInterface1Impl| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|kotlin/String| {
+            ^data String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
+            ^data2 String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|kotlin/String| {
+            ^data3 String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun data2Blocking(value: R|kotlin/Int|): R|kotlin/String|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun dataBlocking(): R|kotlin/String|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun R|kotlin/Int|.data3Blocking(): R|kotlin/String|
+
+    }
+    public abstract interface FooInterface2 : R|kotlin/Any| {
+        public abstract suspend fun data(): R|kotlin/String|
+
+        public open fun dataBlocking(): R|kotlin/String| {
+            ^dataBlocking String()
+        }
+
+        public abstract suspend fun data2(value: R|kotlin/Int|): R|kotlin/String|
+
+        public open fun data2Blocking(value: R|kotlin/Int|): R|kotlin/String| {
+            ^data2Blocking String()
+        }
+
+        public abstract suspend fun R|kotlin/Int|.data3(): R|kotlin/String|
+
+        public open fun R|kotlin/Int|.data3Blocking(): R|kotlin/String| {
+            ^data3Blocking String()
+        }
+
+    }
+    public final class FooInterface2Impl : R|FooInterface2| {
+        public constructor(): R|FooInterface2Impl| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|kotlin/String| {
+            ^data String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
+            ^data2 String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|kotlin/String| {
+            ^data3 String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override fun data2Blocking(value: R|kotlin/Int|): R|kotlin/String|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override fun dataBlocking(): R|kotlin/String|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override fun R|kotlin/Int|.data3Blocking(): R|kotlin/String|
+
+    }
+    public abstract interface FooInterface3 : R|kotlin/Any| {
+        public abstract suspend fun data(): R|kotlin/String|
+
+        public open val dataBlocking: R|kotlin/String|
+            public get(): R|kotlin/String| {
+                ^ String()
+            }
+
+    }
+    public final class FooInterface3Impl : R|FooInterface3| {
+        public constructor(): R|FooInterface3Impl| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true)) public open override suspend fun data(): R|kotlin/String| {
+            ^data String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override val dataBlocking: R|kotlin/String|
+            @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public get(): R|kotlin/String|
+
+    }
+    public abstract interface FooInterface4 : R|kotlin/Any| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data(): R|kotlin/String|
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data2(value: R|kotlin/Int|): R|kotlin/String|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun data2Blocking(value: R|kotlin/Int|): R|kotlin/String|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun dataBlocking(): R|kotlin/String|
+
+    }
+    public final class FooInterface4Impl : R|FooInterface4| {
+        public constructor(): R|FooInterface4Impl| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|kotlin/String| {
+            ^data String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
+            ^data2 String()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override fun data2Blocking(value: R|kotlin/Int|): R|kotlin/String|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override fun dataBlocking(): R|kotlin/String|
+
+    }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.kt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.kt
@@ -1,0 +1,74 @@
+// FIR_DUMP
+// DUMP_IR
+// SOURCE
+// FILE: Main.kt [MainKt#main]
+
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
+import love.forte.plugin.suspendtrans.annotation.JvmAsync
+
+interface FooInterface1 {
+    suspend fun data(): String
+    suspend fun data2(value: Int): String
+    suspend fun Int.data3(): String
+}
+
+class FooInterface1Impl : FooInterface1 {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data(): String = ""
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data2(value: Int): String = ""
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun Int.data3(): String = ""
+}
+
+interface FooInterface2 {
+    suspend fun data(): String
+    fun dataBlocking(): String = ""
+
+    suspend fun data2(value: Int): String
+    fun data2Blocking(value: Int): String = ""
+
+    suspend fun Int.data3(): String
+    fun Int.data3Blocking(): String = ""
+}
+
+class FooInterface2Impl : FooInterface2 {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data(): String = ""
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data2(value: Int): String = ""
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun Int.data3(): String = ""
+}
+
+
+interface FooInterface3 {
+    suspend fun data(): String
+    val dataBlocking: String get() = ""
+}
+
+class FooInterface3Impl : FooInterface3 {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking(asProperty = true)
+    override suspend fun data(): String = ""
+}
+
+interface FooInterface4 {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    suspend fun data(): String
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    suspend fun data2(value: Int): String
+}
+
+class FooInterface4Impl : FooInterface4 {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data(): String = ""
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data2(value: Int): String = ""
+}
+

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.asm.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.asm.txt
@@ -1,0 +1,451 @@
+public abstract interface Bar : java/lang/Object, Foo {
+
+}
+
+public abstract interface Foo : java/lang/Object {
+
+}
+
+public abstract interface FooInterface1 : java/lang/Object {
+    public abstract java.lang.Object data(kotlin.coroutines.Continuation p0)
+
+    public abstract java.lang.Object data2(java.lang.Object p0, kotlin.coroutines.Continuation p1)
+
+    public abstract java.lang.Object data3(int p0, kotlin.coroutines.Continuation p1)
+}
+
+final class FooInterface1Impl$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final java.lang.Object $value
+
+    int label
+
+    final FooInterface1Impl this$0
+
+    void <init>(FooInterface1Impl $receiver, java.lang.Object $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface1Impl$data3Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $this_data3Blocking
+
+    int label
+
+    final FooInterface1Impl this$0
+
+    void <init>(FooInterface1Impl $receiver, int $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface1Impl$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface1Impl this$0
+
+    void <init>(FooInterface1Impl $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class FooInterface1Impl : java/lang/Object, FooInterface1 {
+    public void <init>()
+
+    public java.lang.Object data(kotlin.coroutines.Continuation $completion)
+
+    public java.lang.Object data2(java.lang.Object value, kotlin.coroutines.Continuation $completion)
+
+    public Bar data2Blocking(java.lang.Object value)
+
+    public java.lang.Object data3(int $this$data3, kotlin.coroutines.Continuation $completion)
+
+    public Bar data3Blocking(int $this$data3Blocking)
+
+    public Bar dataBlocking()
+}
+
+public abstract interface FooInterface2 : java/lang/Object {
+    public abstract java.lang.Object data(kotlin.coroutines.Continuation p0)
+
+    public abstract java.lang.Object data2(Foo p0, kotlin.coroutines.Continuation p1)
+
+    public abstract java.lang.Object data3(int p0, kotlin.coroutines.Continuation p1)
+}
+
+final class FooInterface2Impl$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final Foo $value
+
+    int label
+
+    final FooInterface2Impl this$0
+
+    void <init>(FooInterface2Impl $receiver, Foo $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface2Impl$data3Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $this_data3Blocking
+
+    int label
+
+    final FooInterface2Impl this$0
+
+    void <init>(FooInterface2Impl $receiver, int $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface2Impl$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface2Impl this$0
+
+    void <init>(FooInterface2Impl $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class FooInterface2Impl : java/lang/Object, FooInterface2 {
+    public void <init>()
+
+    public java.lang.Object data(kotlin.coroutines.Continuation $completion)
+
+    public java.lang.Object data2(Foo value, kotlin.coroutines.Continuation $completion)
+
+    public Foo data2Blocking(Foo value)
+
+    public java.lang.Object data3(int $this$data3, kotlin.coroutines.Continuation $completion)
+
+    public Foo data3Blocking(int $this$data3Blocking)
+
+    public Foo dataBlocking()
+}
+
+public final class FooInterface3$DefaultImpls : java/lang/Object {
+    public static Foo data2Blocking(FooInterface3 $this, java.lang.Object value)
+
+    public static Foo data3Blocking(FooInterface3 $this, int $receiver)
+
+    public static Foo dataBlocking(FooInterface3 $this)
+}
+
+final class FooInterface3$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final java.lang.Object $value
+
+    int label
+
+    final FooInterface3 this$0
+
+    void <init>(FooInterface3 $receiver, java.lang.Object $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface3$data3Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $this_data3Blocking
+
+    int label
+
+    final FooInterface3 this$0
+
+    void <init>(FooInterface3 $receiver, int $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface3$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface3 this$0
+
+    void <init>(FooInterface3 $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public abstract interface FooInterface3 : java/lang/Object {
+    public abstract java.lang.Object data(kotlin.coroutines.Continuation p0)
+
+    public abstract java.lang.Object data2(java.lang.Object p0, kotlin.coroutines.Continuation p1)
+
+    public abstract Foo data2Blocking(java.lang.Object p0)
+
+    public abstract java.lang.Object data3(int p0, kotlin.coroutines.Continuation p1)
+
+    public abstract Foo data3Blocking(int p0)
+
+    public abstract Foo dataBlocking()
+}
+
+final class FooInterface3Impl$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final java.lang.Object $value
+
+    int label
+
+    final FooInterface3Impl this$0
+
+    void <init>(FooInterface3Impl $receiver, java.lang.Object $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface3Impl$data3Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $this_data3Blocking
+
+    int label
+
+    final FooInterface3Impl this$0
+
+    void <init>(FooInterface3Impl $receiver, int $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface3Impl$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface3Impl this$0
+
+    void <init>(FooInterface3Impl $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class FooInterface3Impl : java/lang/Object, FooInterface3 {
+    public void <init>()
+
+    public java.lang.Object data(kotlin.coroutines.Continuation $completion)
+
+    public java.lang.Object data2(java.lang.Object value, kotlin.coroutines.Continuation $completion)
+
+    public Bar data2Blocking(java.lang.Object value)
+
+    public Bar data2Blocking(java.lang.Object value)
+
+    public Foo data2Blocking(java.lang.Object value)
+
+    public java.lang.Object data3(int $this$data3, kotlin.coroutines.Continuation $completion)
+
+    public Bar data3Blocking(int $this$data3Blocking)
+
+    public Foo data3Blocking(int $this$data3Blocking)
+
+    public Bar dataBlocking()
+
+    public Foo dataBlocking()
+}
+
+public final class FooInterface4$DefaultImpls : java/lang/Object {
+    public static Foo data2Blocking(FooInterface4 $this, Foo value)
+
+    public static Foo data3Blocking(FooInterface4 $this, int $receiver)
+
+    public static Foo dataBlocking(FooInterface4 $this)
+}
+
+final class FooInterface4$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final Foo $value
+
+    int label
+
+    final FooInterface4 this$0
+
+    void <init>(FooInterface4 $receiver, Foo $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface4$data3Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $this_data3Blocking
+
+    int label
+
+    final FooInterface4 this$0
+
+    void <init>(FooInterface4 $receiver, int $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface4$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface4 this$0
+
+    void <init>(FooInterface4 $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public abstract interface FooInterface4 : java/lang/Object {
+    public abstract java.lang.Object data(kotlin.coroutines.Continuation p0)
+
+    public abstract java.lang.Object data2(Foo p0, kotlin.coroutines.Continuation p1)
+
+    public abstract Foo data2Blocking(Foo p0)
+
+    public abstract java.lang.Object data3(int p0, kotlin.coroutines.Continuation p1)
+
+    public abstract Foo data3Blocking(int p0)
+
+    public abstract Foo dataBlocking()
+}
+
+final class FooInterface4Impl$data2Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final Foo $value
+
+    int label
+
+    final FooInterface4Impl this$0
+
+    void <init>(FooInterface4Impl $receiver, Foo $value, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface4Impl$data3Blocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final int $this_data3Blocking
+
+    int label
+
+    final FooInterface4Impl this$0
+
+    void <init>(FooInterface4Impl $receiver, int $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class FooInterface4Impl$dataBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    int label
+
+    final FooInterface4Impl this$0
+
+    void <init>(FooInterface4Impl $receiver, kotlin.coroutines.Continuation $completion)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class FooInterface4Impl : java/lang/Object, FooInterface4 {
+    public void <init>()
+
+    public java.lang.Object data(kotlin.coroutines.Continuation $completion)
+
+    public java.lang.Object data2(Foo value, kotlin.coroutines.Continuation $completion)
+
+    public Foo data2Blocking(Foo value)
+
+    public java.lang.Object data3(int $this$data3, kotlin.coroutines.Continuation $completion)
+
+    public Foo data3Blocking(int $this$data3Blocking)
+
+    public Foo dataBlocking()
+}

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.fir.ir.txt
@@ -1,0 +1,657 @@
+FILE fqName:<root> fileName:/Main.kt
+  CLASS CLASS name:FooInterface1Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface1<T of <root>.FooInterface1Impl>]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.Bar] reified:false
+    CONSTRUCTOR visibility:public <> () returnType:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl> [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FooInterface1Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface1<T of <root>.FooInterface1Impl>]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <A> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>, value:A of <root>.FooInterface1Impl.data2) returnType:T of <root>.FooInterface1Impl
+      annotations:
+        Api4J
+      TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>
+      VALUE_PARAMETER name:value index:0 type:A of <root>.FooInterface1Impl.data2
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking <A> (value: A of <root>.FooInterface1Impl.data2): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface1Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface1Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl.data2Blocking'
+                    CALL 'public open fun data2 <A> (value: A of <root>.FooInterface1Impl.data2): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl' type=T of <root>.FooInterface1Impl origin=null
+                      <A>: <none>
+                      $this: GET_VAR '<this>: <root>.FooInterface1Impl<T of <root>.FooInterface1Impl> declared in <root>.FooInterface1Impl.data2Blocking' type=<root>.FooInterface1Impl<T of <root>.FooInterface1Impl> origin=null
+                      value: GET_VAR 'value: A of <root>.FooInterface1Impl.data2 declared in <root>.FooInterface1Impl.data2Blocking' type=A of <root>.FooInterface1Impl.data2 origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface1Impl
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface1Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface1Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl.data3Blocking'
+                    CALL 'public open fun data3 (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl' type=T of <root>.FooInterface1Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface1Impl<T of <root>.FooInterface1Impl> declared in <root>.FooInterface1Impl.data3Blocking' type=<root>.FooInterface1Impl<T of <root>.FooInterface1Impl> origin=null
+                      $receiver: GET_VAR '<this>: kotlin.Int declared in <root>.FooInterface1Impl.data3Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>) returnType:T of <root>.FooInterface1Impl
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface1Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface1Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl.dataBlocking'
+                    CALL 'public open fun data (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl' type=T of <root>.FooInterface1Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface1Impl<T of <root>.FooInterface1Impl> declared in <root>.FooInterface1Impl.dataBlocking' type=<root>.FooInterface1Impl<T of <root>.FooInterface1Impl> origin=null
+    FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>) returnType:T of <root>.FooInterface1Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data (): T of <root>.FooInterface1 declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+    FUN name:data2 visibility:public modality:OPEN <A> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>, value:A of <root>.FooInterface1Impl.data2) returnType:T of <root>.FooInterface1Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data2 <A> (value: A of <root>.FooInterface1.data2): T of <root>.FooInterface1 declared in <root>.FooInterface1
+      TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>
+      VALUE_PARAMETER name:value index:0 type:A of <root>.FooInterface1Impl.data2
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2 <A> (value: A of <root>.FooInterface1Impl.data2): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+    FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface1Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data3 (): T of <root>.FooInterface1 declared in <root>.FooInterface1
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3 (): T of <root>.FooInterface1Impl declared in <root>.FooInterface1Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+  CLASS CLASS name:FooInterface2Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface2<T of <root>.FooInterface2Impl>]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.Foo] reified:false
+    CONSTRUCTOR visibility:public <> () returnType:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl> [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FooInterface2Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface2<T of <root>.FooInterface2Impl>]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>, value:T of <root>.FooInterface2Impl) returnType:T of <root>.FooInterface2Impl
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>
+      VALUE_PARAMETER name:value index:0 type:T of <root>.FooInterface2Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking (value: T of <root>.FooInterface2Impl): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface2Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface2Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl.data2Blocking'
+                    CALL 'public open fun data2 (value: T of <root>.FooInterface2Impl): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl' type=T of <root>.FooInterface2Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface2Impl<T of <root>.FooInterface2Impl> declared in <root>.FooInterface2Impl.data2Blocking' type=<root>.FooInterface2Impl<T of <root>.FooInterface2Impl> origin=null
+                      value: GET_VAR 'value: T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl.data2Blocking' type=T of <root>.FooInterface2Impl origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface2Impl
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface2Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface2Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl.data3Blocking'
+                    CALL 'public open fun data3 (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl' type=T of <root>.FooInterface2Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface2Impl<T of <root>.FooInterface2Impl> declared in <root>.FooInterface2Impl.data3Blocking' type=<root>.FooInterface2Impl<T of <root>.FooInterface2Impl> origin=null
+                      $receiver: GET_VAR '<this>: kotlin.Int declared in <root>.FooInterface2Impl.data3Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>) returnType:T of <root>.FooInterface2Impl
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface2Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface2Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl.dataBlocking'
+                    CALL 'public open fun data (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl' type=T of <root>.FooInterface2Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface2Impl<T of <root>.FooInterface2Impl> declared in <root>.FooInterface2Impl.dataBlocking' type=<root>.FooInterface2Impl<T of <root>.FooInterface2Impl> origin=null
+    FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>) returnType:T of <root>.FooInterface2Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data (): T of <root>.FooInterface2 declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+    FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>, value:T of <root>.FooInterface2Impl) returnType:T of <root>.FooInterface2Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data2 (value: T of <root>.FooInterface2): T of <root>.FooInterface2 declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>
+      VALUE_PARAMETER name:value index:0 type:T of <root>.FooInterface2Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2 (value: T of <root>.FooInterface2Impl): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+    FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface2Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data3 (): T of <root>.FooInterface2 declared in <root>.FooInterface2
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3 (): T of <root>.FooInterface2Impl declared in <root>.FooInterface2Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+  CLASS CLASS name:FooInterface3Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface3<T of <root>.FooInterface3Impl>]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.Bar] reified:false
+    CONSTRUCTOR visibility:public <> () returnType:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl> [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FooInterface3Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface3<T of <root>.FooInterface3Impl>]'
+    FUN FAKE_OVERRIDE name:data2Blocking visibility:public modality:OPEN <A> ($this:<root>.FooInterface3<T of <root>.FooInterface3Impl>, value:A of <root>.FooInterface3.data2) returnType:T of <root>.FooInterface3Impl [fake_override]
+      annotations:
+        Api4J
+      overridden:
+        public open fun data2Blocking <A> (value: A of <root>.FooInterface3.data2): T of <root>.FooInterface3 declared in <root>.FooInterface3
+      TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3Impl>
+      VALUE_PARAMETER name:value index:0 type:A of <root>.FooInterface3.data2
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <A> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>, value:A of <root>.FooInterface3Impl.data2) returnType:T of <root>.FooInterface3Impl
+      annotations:
+        Api4J
+      TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>
+      VALUE_PARAMETER name:value index:0 type:A of <root>.FooInterface3Impl.data2
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking <A> (value: A of <root>.FooInterface3Impl.data2): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface3Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface3Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl.data2Blocking'
+                    CALL 'public open fun data2 <A> (value: A of <root>.FooInterface3Impl.data2): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl' type=T of <root>.FooInterface3Impl origin=null
+                      <A>: <none>
+                      $this: GET_VAR '<this>: <root>.FooInterface3Impl<T of <root>.FooInterface3Impl> declared in <root>.FooInterface3Impl.data2Blocking' type=<root>.FooInterface3Impl<T of <root>.FooInterface3Impl> origin=null
+                      value: GET_VAR 'value: A of <root>.FooInterface3Impl.data2 declared in <root>.FooInterface3Impl.data2Blocking' type=A of <root>.FooInterface3Impl.data2 origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface3Impl
+      annotations:
+        Api4J
+      overridden:
+        public open fun data3Blocking (): T of <root>.FooInterface3 declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface3Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface3Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl.data3Blocking'
+                    CALL 'public open fun data3 (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl' type=T of <root>.FooInterface3Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface3Impl<T of <root>.FooInterface3Impl> declared in <root>.FooInterface3Impl.data3Blocking' type=<root>.FooInterface3Impl<T of <root>.FooInterface3Impl> origin=null
+                      $receiver: GET_VAR '<this>: kotlin.Int declared in <root>.FooInterface3Impl.data3Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>) returnType:T of <root>.FooInterface3Impl
+      annotations:
+        Api4J
+      overridden:
+        public open fun dataBlocking (): T of <root>.FooInterface3 declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface3Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface3Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl.dataBlocking'
+                    CALL 'public open fun data (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl' type=T of <root>.FooInterface3Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface3Impl<T of <root>.FooInterface3Impl> declared in <root>.FooInterface3Impl.dataBlocking' type=<root>.FooInterface3Impl<T of <root>.FooInterface3Impl> origin=null
+    FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>) returnType:T of <root>.FooInterface3Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data (): T of <root>.FooInterface3 declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+    FUN name:data2 visibility:public modality:OPEN <A> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>, value:A of <root>.FooInterface3Impl.data2) returnType:T of <root>.FooInterface3Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data2 <A> (value: A of <root>.FooInterface3.data2): T of <root>.FooInterface3 declared in <root>.FooInterface3
+      TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>
+      VALUE_PARAMETER name:value index:0 type:A of <root>.FooInterface3Impl.data2
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2 <A> (value: A of <root>.FooInterface3Impl.data2): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+    FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface3Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data3 (): T of <root>.FooInterface3 declared in <root>.FooInterface3
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3 (): T of <root>.FooInterface3Impl declared in <root>.FooInterface3Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+  CLASS CLASS name:FooInterface4Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface4<T of <root>.FooInterface4Impl>]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.Foo] reified:false
+    CONSTRUCTOR visibility:public <> () returnType:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl> [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FooInterface4Impl modality:FINAL visibility:public superTypes:[<root>.FooInterface4<T of <root>.FooInterface4Impl>]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>, value:T of <root>.FooInterface4Impl) returnType:T of <root>.FooInterface4Impl
+      annotations:
+        Api4J
+      overridden:
+        public open fun data2Blocking (value: T of <root>.FooInterface4): T of <root>.FooInterface4 declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>
+      VALUE_PARAMETER name:value index:0 type:T of <root>.FooInterface4Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking (value: T of <root>.FooInterface4Impl): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface4Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface4Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl.data2Blocking'
+                    CALL 'public open fun data2 (value: T of <root>.FooInterface4Impl): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl' type=T of <root>.FooInterface4Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4Impl<T of <root>.FooInterface4Impl> declared in <root>.FooInterface4Impl.data2Blocking' type=<root>.FooInterface4Impl<T of <root>.FooInterface4Impl> origin=null
+                      value: GET_VAR 'value: T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl.data2Blocking' type=T of <root>.FooInterface4Impl origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface4Impl
+      annotations:
+        Api4J
+      overridden:
+        public open fun data3Blocking (): T of <root>.FooInterface4 declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface4Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface4Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl.data3Blocking'
+                    CALL 'public open fun data3 (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl' type=T of <root>.FooInterface4Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4Impl<T of <root>.FooInterface4Impl> declared in <root>.FooInterface4Impl.data3Blocking' type=<root>.FooInterface4Impl<T of <root>.FooInterface4Impl> origin=null
+                      $receiver: GET_VAR '<this>: kotlin.Int declared in <root>.FooInterface4Impl.data3Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>) returnType:T of <root>.FooInterface4Impl
+      annotations:
+        Api4J
+      overridden:
+        public open fun dataBlocking (): T of <root>.FooInterface4 declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface4Impl> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface4Impl [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl.dataBlocking'
+                    CALL 'public open fun data (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl' type=T of <root>.FooInterface4Impl origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4Impl<T of <root>.FooInterface4Impl> declared in <root>.FooInterface4Impl.dataBlocking' type=<root>.FooInterface4Impl<T of <root>.FooInterface4Impl> origin=null
+    FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>) returnType:T of <root>.FooInterface4Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data (): T of <root>.FooInterface4 declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+    FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>, value:T of <root>.FooInterface4Impl) returnType:T of <root>.FooInterface4Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data2 (value: T of <root>.FooInterface4): T of <root>.FooInterface4 declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>
+      VALUE_PARAMETER name:value index:0 type:T of <root>.FooInterface4Impl
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2 (value: T of <root>.FooInterface4Impl): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+    FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface4Impl [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      overridden:
+        public abstract fun data3 (): T of <root>.FooInterface4 declared in <root>.FooInterface4
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3 (): T of <root>.FooInterface4Impl declared in <root>.FooInterface4Impl'
+          CALL 'public final fun TODO (): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+  CLASS INTERFACE name:Bar modality:ABSTRACT visibility:public superTypes:[<root>.Foo]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Bar
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Foo
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.Foo
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.Foo
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS INTERFACE name:Foo modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Foo
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS INTERFACE name:FooInterface1 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface1<T of <root>.FooInterface1>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.Foo] reified:false
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface1<T of <root>.FooInterface1>) returnType:T of <root>.FooInterface1 [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1<T of <root>.FooInterface1>
+    FUN name:data2 visibility:public modality:ABSTRACT <A> ($this:<root>.FooInterface1<T of <root>.FooInterface1>, value:A of <root>.FooInterface1.data2) returnType:T of <root>.FooInterface1 [suspend]
+      TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1<T of <root>.FooInterface1>
+      VALUE_PARAMETER name:value index:0 type:A of <root>.FooInterface1.data2
+    FUN name:data3 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface1<T of <root>.FooInterface1>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface1 [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface1<T of <root>.FooInterface1>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+  CLASS INTERFACE name:FooInterface2 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface2<T of <root>.FooInterface2>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.Foo] reified:false
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface2<T of <root>.FooInterface2>) returnType:T of <root>.FooInterface2 [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2<T of <root>.FooInterface2>
+    FUN name:data2 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface2<T of <root>.FooInterface2>, value:T of <root>.FooInterface2) returnType:T of <root>.FooInterface2 [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2<T of <root>.FooInterface2>
+      VALUE_PARAMETER name:value index:0 type:T of <root>.FooInterface2
+    FUN name:data3 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface2<T of <root>.FooInterface2>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface2 [suspend]
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface2<T of <root>.FooInterface2>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+  CLASS INTERFACE name:FooInterface3 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.Foo] reified:false
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <A> ($this:<root>.FooInterface3<T of <root>.FooInterface3>, value:A of <root>.FooInterface3.data2) returnType:T of <root>.FooInterface3
+      annotations:
+        Api4J
+      TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
+      VALUE_PARAMETER name:value index:0 type:A of <root>.FooInterface3.data2
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking <A> (value: A of <root>.FooInterface3.data2): T of <root>.FooInterface3 declared in <root>.FooInterface3'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface3> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface3 [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface3 declared in <root>.FooInterface3.data2Blocking'
+                    CALL 'public abstract fun data2 <A> (value: A of <root>.FooInterface3.data2): T of <root>.FooInterface3 declared in <root>.FooInterface3' type=T of <root>.FooInterface3 origin=null
+                      <A>: <none>
+                      $this: GET_VAR '<this>: <root>.FooInterface3<T of <root>.FooInterface3> declared in <root>.FooInterface3.data2Blocking' type=<root>.FooInterface3<T of <root>.FooInterface3> origin=null
+                      value: GET_VAR 'value: A of <root>.FooInterface3.data2 declared in <root>.FooInterface3.data2Blocking' type=A of <root>.FooInterface3.data2 origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface3<T of <root>.FooInterface3>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface3
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): T of <root>.FooInterface3 declared in <root>.FooInterface3'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface3> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface3 [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface3 declared in <root>.FooInterface3.data3Blocking'
+                    CALL 'public abstract fun data3 (): T of <root>.FooInterface3 declared in <root>.FooInterface3' type=T of <root>.FooInterface3 origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface3<T of <root>.FooInterface3> declared in <root>.FooInterface3.data3Blocking' type=<root>.FooInterface3<T of <root>.FooInterface3> origin=null
+                      $receiver: GET_VAR '<this>: kotlin.Int declared in <root>.FooInterface3.data3Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface3<T of <root>.FooInterface3>) returnType:T of <root>.FooInterface3
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): T of <root>.FooInterface3 declared in <root>.FooInterface3'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface3> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface3 [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface3 declared in <root>.FooInterface3.dataBlocking'
+                    CALL 'public abstract fun data (): T of <root>.FooInterface3 declared in <root>.FooInterface3' type=T of <root>.FooInterface3 origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface3<T of <root>.FooInterface3> declared in <root>.FooInterface3.dataBlocking' type=<root>.FooInterface3<T of <root>.FooInterface3> origin=null
+    FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface3<T of <root>.FooInterface3>) returnType:T of <root>.FooInterface3 [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
+    FUN name:data2 visibility:public modality:ABSTRACT <A> ($this:<root>.FooInterface3<T of <root>.FooInterface3>, value:A of <root>.FooInterface3.data2) returnType:T of <root>.FooInterface3 [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
+      VALUE_PARAMETER name:value index:0 type:A of <root>.FooInterface3.data2
+    FUN name:data3 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface3<T of <root>.FooInterface3>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface3 [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+  CLASS INTERFACE name:FooInterface4 modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[<root>.Foo] reified:false
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data2Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>, value:T of <root>.FooInterface4) returnType:T of <root>.FooInterface4
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
+      VALUE_PARAMETER name:value index:0 type:T of <root>.FooInterface4
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data2Blocking (value: T of <root>.FooInterface4): T of <root>.FooInterface4 declared in <root>.FooInterface4'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface4> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface4 [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface4 declared in <root>.FooInterface4.data2Blocking'
+                    CALL 'public abstract fun data2 (value: T of <root>.FooInterface4): T of <root>.FooInterface4 declared in <root>.FooInterface4' type=T of <root>.FooInterface4 origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4<T of <root>.FooInterface4> declared in <root>.FooInterface4.data2Blocking' type=<root>.FooInterface4<T of <root>.FooInterface4> origin=null
+                      value: GET_VAR 'value: T of <root>.FooInterface4 declared in <root>.FooInterface4.data2Blocking' type=T of <root>.FooInterface4 origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:data3Blocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface4
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun data3Blocking (): T of <root>.FooInterface4 declared in <root>.FooInterface4'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface4> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface4 [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface4 declared in <root>.FooInterface4.data3Blocking'
+                    CALL 'public abstract fun data3 (): T of <root>.FooInterface4 declared in <root>.FooInterface4' type=T of <root>.FooInterface4 origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4<T of <root>.FooInterface4> declared in <root>.FooInterface4.data3Blocking' type=<root>.FooInterface4<T of <root>.FooInterface4> origin=null
+                      $receiver: GET_VAR '<this>: kotlin.Int declared in <root>.FooInterface4.data3Blocking' type=kotlin.Int origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:dataBlocking visibility:public modality:OPEN <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>) returnType:T of <root>.FooInterface4
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun dataBlocking (): T of <root>.FooInterface4 declared in <root>.FooInterface4'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<T of <root>.FooInterface4> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:T of <root>.FooInterface4 [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): T of <root>.FooInterface4 declared in <root>.FooInterface4.dataBlocking'
+                    CALL 'public abstract fun data (): T of <root>.FooInterface4 declared in <root>.FooInterface4' type=T of <root>.FooInterface4 origin=null
+                      $this: GET_VAR '<this>: <root>.FooInterface4<T of <root>.FooInterface4> declared in <root>.FooInterface4.dataBlocking' type=<root>.FooInterface4<T of <root>.FooInterface4> origin=null
+    FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>) returnType:T of <root>.FooInterface4 [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
+    FUN name:data2 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>, value:T of <root>.FooInterface4) returnType:T of <root>.FooInterface4 [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
+      VALUE_PARAMETER name:value index:0 type:T of <root>.FooInterface4
+    FUN name:data3 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface4 [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmSynthetic
+      $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
+      $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.fir.txt
@@ -1,0 +1,145 @@
+FILE: Main.kt
+    public abstract interface Foo : R|kotlin/Any| {
+    }
+    public abstract interface Bar : R|Foo| {
+    }
+    public abstract interface FooInterface1<T : R|Foo|> : R|kotlin/Any| {
+        public abstract suspend fun data(): R|T|
+
+        public abstract suspend fun <A> data2(value: R|A|): R|T|
+
+        public abstract suspend fun R|kotlin/Int|.data3(): R|T|
+
+    }
+    public final class FooInterface1Impl<T : R|Bar|> : R|FooInterface1<T>| {
+        public constructor<T : R|Bar|>(): R|FooInterface1Impl<T>| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|T| {
+            ^data R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun <A> data2(value: R|A|): R|T| {
+            ^data2 R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|T| {
+            ^data3 R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun <A> data2Blocking(value: R|A|): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun dataBlocking(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun R|kotlin/Int|.data3Blocking(): R|T|
+
+    }
+    public abstract interface FooInterface2<T : R|Foo|> : R|kotlin/Any| {
+        public abstract suspend fun data(): R|T|
+
+        public abstract suspend fun data2(value: R|T|): R|T|
+
+        public abstract suspend fun R|kotlin/Int|.data3(): R|T|
+
+    }
+    public final class FooInterface2Impl<T : R|Foo|> : R|FooInterface2<T>| {
+        public constructor<T : R|Foo|>(): R|FooInterface2Impl<T>| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|T| {
+            ^data R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|T|): R|T| {
+            ^data2 R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|T| {
+            ^data3 R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun data2Blocking(value: R|T|): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun dataBlocking(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun R|kotlin/Int|.data3Blocking(): R|T|
+
+    }
+    public abstract interface FooInterface3<T : R|Foo|> : R|kotlin/Any| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun <A> data2(value: R|A|): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun R|kotlin/Int|.data3(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun <A> data2Blocking(value: R|A|): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun dataBlocking(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun R|kotlin/Int|.data3Blocking(): R|T|
+
+    }
+    public final class FooInterface3Impl<T : R|Bar|> : R|FooInterface3<T>| {
+        public constructor<T : R|Bar|>(): R|FooInterface3Impl<T>| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|T| {
+            ^data R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun <A> data2(value: R|A|): R|T| {
+            ^data2 R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|T| {
+            ^data3 R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun <A> data2Blocking(value: R|A|): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override fun dataBlocking(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun R|kotlin/Int|.data3Blocking(): R|T|
+
+    }
+    public abstract interface FooInterface4<T : R|Foo|> : R|kotlin/Any| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data2(value: R|T|): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun R|kotlin/Int|.data3(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun data2Blocking(value: R|T|): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun dataBlocking(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun R|kotlin/Int|.data3Blocking(): R|T|
+
+    }
+    public final class FooInterface4Impl<T : R|Foo|> : R|FooInterface4<T>| {
+        public constructor<T : R|Foo|>(): R|FooInterface4Impl<T>| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|T| {
+            ^data R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|T|): R|T| {
+            ^data2 R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|T| {
+            ^data3 R|kotlin/TODO|()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override fun data2Blocking(value: R|T|): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open override fun dataBlocking(): R|T|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun R|kotlin/Int|.data3Blocking(): R|T|
+
+    }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.kt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.kt
@@ -1,0 +1,83 @@
+// FIR_DUMP
+// DUMP_IR
+// SOURCE
+// FILE: Main.kt [MainKt#main]
+
+interface Foo
+interface Bar : Foo
+
+
+interface FooInterface1<T : Foo> {
+    suspend fun data(): T
+    suspend fun <A> data2(value: A): T
+    suspend fun Int.data3(): T
+}
+
+class FooInterface1Impl<T : Bar> : FooInterface1<T> {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data(): T = TODO()
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun <A> data2(value: A): T = TODO()
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun Int.data3(): T = TODO()
+}
+
+interface FooInterface2<T : Foo> {
+    suspend fun data(): T
+    suspend fun data2(value: T): T
+    suspend fun Int.data3(): T
+}
+
+class FooInterface2Impl<T : Foo> : FooInterface2<T> {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data(): T = TODO()
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data2(value: T): T = TODO()
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun Int.data3(): T = TODO()
+}
+
+interface FooInterface3<T : Foo> {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    suspend fun data(): T
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    suspend fun <A> data2(value: A): T
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    suspend fun Int.data3(): T
+}
+
+class FooInterface3Impl<T : Bar> : FooInterface3<T> {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data(): T = TODO()
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun <A> data2(value: A): T = TODO()
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun Int.data3(): T = TODO()
+}
+
+interface FooInterface4<T : Foo> {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    suspend fun data(): T
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    suspend fun data2(value: T): T
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    suspend fun Int.data3(): T
+}
+
+class FooInterface4Impl<T : Foo> : FooInterface4<T> {
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data(): T = TODO()
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun data2(value: T): T = TODO()
+
+    @love.forte.plugin.suspendtrans.annotation.JvmBlocking
+    override suspend fun Int.data3(): T = TODO()
+}
+

--- a/tests/test-js/build.gradle.kts
+++ b/tests/test-js/build.gradle.kts
@@ -15,7 +15,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-Beta1-0.9.2")
+        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-Beta1-0.9.3")
+        classpath("org.jetbrains.kotlin:kotlin-compiler:2.1.0-Beta1")
     }
 }
 

--- a/tests/test-js/src/jsMain/kotlin/FooInterface.kt
+++ b/tests/test-js/src/jsMain/kotlin/FooInterface.kt
@@ -1,0 +1,80 @@
+@file:OptIn(ExperimentalJsExport::class)
+@file:JsExport
+
+import love.forte.plugin.suspendtrans.annotation.JsPromise
+
+/**
+ *
+ * @author ForteScarlet
+ */
+interface FooInterface {
+    @JsExport.Ignore
+    suspend fun run1(value: Int): String
+
+    @JsExport.Ignore
+    suspend fun run2(): String
+}
+
+class FooImpl : FooInterface {
+    @JsExport.Ignore
+    @JsPromise
+    override suspend fun run1(value: Int): String = value.toString()
+
+    @JsExport.Ignore
+    @JsPromise // TODO asProperty
+    override suspend fun run2(): String = ""
+}
+
+/**
+ *
+ * @author ForteScarlet
+ */
+interface FooInterface2 {
+    @JsExport.Ignore
+    @JsPromise
+    suspend fun run1(value: Int): String
+
+    @JsExport.Ignore
+    @JsPromise // TODO asProperty
+    suspend fun run2(): String
+}
+
+
+class FooImpl2 : FooInterface2 {
+    @JsExport.Ignore
+    @JsPromise
+    override suspend fun run1(value: Int): String = value.toString()
+
+    @JsExport.Ignore
+    @JsPromise // TODO asProperty
+    override suspend fun run2(): String = ""
+}
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+interface FooInterface3 {
+    @JsExport.Ignore
+    suspend fun run1(value: Int): String
+
+    fun run1Blocking(value: Int): String = value.toString()
+
+    @JsExport.Ignore
+    @JsName("suspend_run2")
+    suspend fun run2(): String
+
+    val run2: String get() = ""
+}
+
+
+class FooImpl3 : FooInterface3 {
+    @JsExport.Ignore
+    @JsPromise
+    override suspend fun run1(value: Int): String = value.toString()
+
+    @JsExport.Ignore
+    @JsPromise // asProperty
+    override suspend fun run2(): String = ""
+}

--- a/tests/test-jvm/build.gradle.kts
+++ b/tests/test-jvm/build.gradle.kts
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-Beta1-0.9.2")
+        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-Beta1-0.9.3")
         classpath("org.jetbrains.kotlin:kotlin-compiler:2.1.0-Beta1")
     }
 }

--- a/tests/test-jvm/src/main/kotlin/love/forte/plugin/suspendtrans/sample/FooInterface.kt
+++ b/tests/test-jvm/src/main/kotlin/love/forte/plugin/suspendtrans/sample/FooInterface.kt
@@ -1,0 +1,74 @@
+package love.forte.plugin.suspendtrans.sample
+
+import love.forte.plugin.suspendtrans.annotation.JvmAsync
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
+
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+interface FooInterface {
+    suspend fun run1(value: Int): String
+    suspend fun run2(): String
+}
+
+class FooImpl : FooInterface {
+    @JvmBlocking
+    @JvmAsync
+    override suspend fun run1(value: Int): String = value.toString()
+
+    @JvmBlocking(asProperty = true)
+    @JvmAsync(asProperty = true)
+    override suspend fun run2(): String = ""
+}
+
+/**
+ *
+ * @author ForteScarlet
+ */
+interface FooInterface2 {
+    @JvmBlocking
+    suspend fun run1(value: Int): String
+
+    @JvmBlocking(asProperty = true)
+    suspend fun run2(): String
+}
+
+
+class FooImpl2 : FooInterface2 {
+    @JvmBlocking
+    @JvmAsync
+    override suspend fun run1(value: Int): String = value.toString()
+
+    @JvmBlocking(asProperty = true)
+    @JvmAsync(asProperty = true)
+    override suspend fun run2(): String = ""
+}
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+interface FooInterface3 {
+    suspend fun run1(value: Int): String
+
+    fun run1Blocking(value: Int): String = value.toString()
+
+    suspend fun run2(): String
+
+    val run2: String get() = ""
+}
+
+
+class FooImpl3 : FooInterface3 {
+    @JvmBlocking
+    @JvmAsync
+    override suspend fun run1(value: Int): String = value.toString()
+
+    @JvmBlocking(asProperty = true)
+    @JvmAsync(asProperty = true)
+    override suspend fun run2(): String = ""
+}


### PR DESCRIPTION
resolve #67

In the previous K2 mode, the `override` of a synthesized function always came directly from the original function.

Now, if the original function is `override`, a judgment is made based on all of its _parent functions_ as to whether the synthetic function should also add `override`.

In the case of `JvmBlocking`, it is assumed that the synthetic function should be `override` if there are any _parent functions_ that also contain this annotation, and the final function name and `asProperty` are also the same.

_Although some other optimizations have been made in addition to judging directly from the original function, they are less recommended ways of using it and may be flawed, so I won't express them._

<details><summary>nothing</summary>
<i><small>One complaint I have to make is that implementing inheritance relationships between judgment functions in the plugin is quite a bit more complicated than I thought it would be. 😢 </small></i>
</details>
