### PR TITLE
Support `baseName`, `suffix` and `asProperty` for `@JsPromise`

### DIFF
--- a/runtime/suspend-transform-annotation/src/commonMain/kotlin/love/forte/plugin/suspendtrans/annotation/SuspendTransformAnnotation.kt
+++ b/runtime/suspend-transform-annotation/src/commonMain/kotlin/love/forte/plugin/suspendtrans/annotation/SuspendTransformAnnotation.kt
@@ -37,8 +37,10 @@ public expect annotation class Api4Js()
 @OptionalExpectation
 public expect annotation class JvmBlocking(
     /**
-     * 生成函数的基础名称，如果为空则为当前函数名。
-     * 最终生成的函数名为 [baseName] + [suffix]。
+     * The base name of synthetic function
+     * or the current function name if empty.
+     *
+     * The final function name is: [baseName] + [suffix]
      */
     val baseName: String = "",
 
@@ -57,7 +59,7 @@ public expect annotation class JvmBlocking(
      * val fooBlocking: T get() = runInBlocking { foo() }
      * ```
      *
-     * 只有函数没有参数时有效。
+     * Note: If [asProperty] == `true`, the function cannot have parameters.
      *
      */
     val asProperty: Boolean = false
@@ -97,8 +99,7 @@ public expect annotation class JvmAsync(
      * val fooAsync: Future<T> get() = runInAsync { foo() }
      * ```
      *
-     * 只有函数没有参数时有效。
-     *
+     * Note: If [asProperty] == `true`, the function cannot have parameters.
      */
     val asProperty: Boolean = false
 )
@@ -108,4 +109,21 @@ public expect annotation class JvmAsync(
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
 @OptionalExpectation
-public expect annotation class JsPromise()
+public expect annotation class JsPromise(
+    val baseName: String = "",
+    val suffix: String = "Async",
+    /**
+     * 是否转化为 property 的形式：
+     *
+     * ```kotlin
+     * suspend fun foo(): T = ...
+     *
+     * // Generated
+     * val fooAsync: Promise<T> get() = runInAsync { foo() }
+     * ```
+     *
+     * Note: If [asProperty] == `true`, the function cannot have parameters.
+     *
+     */
+    val asProperty: Boolean = false
+)

--- a/runtime/suspend-transform-annotation/src/jsMain/kotlin/love.forte.plugin.suspendtrans/annotation/SuspendTransformAnnotationJs.kt
+++ b/runtime/suspend-transform-annotation/src/jsMain/kotlin/love.forte.plugin.suspendtrans/annotation/SuspendTransformAnnotationJs.kt
@@ -10,4 +10,8 @@ public annotation class ExperimentalJsApi
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
-public actual annotation class JsPromise
+public actual annotation class JsPromise(
+    actual val baseName: String,
+    actual val suffix: String,
+    actual val asProperty: Boolean,
+)

--- a/tests/test-js/build.gradle.kts
+++ b/tests/test-js/build.gradle.kts
@@ -55,12 +55,17 @@ kotlin {
             dependencies {
                 implementation(kotlin("stdlib"))
                 api(libs.kotlinx.coroutines.core)
+                api(project(":runtime:suspend-transform-annotation"))
+                api(project(":runtime:suspend-transform-runtime"))
             }
         }
     }
 }
 
 extensions.getByType<SuspendTransformGradleExtension>().apply {
+    includeRuntime = false
+    includeAnnotation = false
+
     transformers[TargetPlatform.JS] = mutableListOf(
         SuspendTransformConfiguration.jsPromiseTransformer.copy(
             copyAnnotationExcludes = listOf(

--- a/tests/test-js/src/jsMain/kotlin/AsPropertyTests.kt
+++ b/tests/test-js/src/jsMain/kotlin/AsPropertyTests.kt
@@ -1,0 +1,16 @@
+@file:OptIn(ExperimentalJsExport::class)
+@file:JsExport
+
+import love.forte.plugin.suspendtrans.annotation.JsPromise
+
+interface AsPropertyInterface {
+    @JsExport.Ignore
+    @JsPromise(asProperty = true)
+    suspend fun value(): String
+}
+
+class AsPropertyImpl : AsPropertyInterface {
+    @JsExport.Ignore
+    @JsPromise(asProperty = true)
+    override suspend fun value(): String = "Hello, World"
+}

--- a/tests/test-js/src/jsMain/kotlin/FooInterface.kt
+++ b/tests/test-js/src/jsMain/kotlin/FooInterface.kt
@@ -21,7 +21,7 @@ class FooImpl : FooInterface {
     override suspend fun run1(value: Int): String = value.toString()
 
     @JsExport.Ignore
-    @JsPromise // TODO asProperty
+    @JsPromise(asProperty = true)
     override suspend fun run2(): String = ""
 }
 
@@ -35,7 +35,7 @@ interface FooInterface2 {
     suspend fun run1(value: Int): String
 
     @JsExport.Ignore
-    @JsPromise // TODO asProperty
+    @JsPromise(asProperty = true)
     suspend fun run2(): String
 }
 
@@ -46,7 +46,7 @@ class FooImpl2 : FooInterface2 {
     override suspend fun run1(value: Int): String = value.toString()
 
     @JsExport.Ignore
-    @JsPromise // TODO asProperty
+    @JsPromise(asProperty = true)
     override suspend fun run2(): String = ""
 }
 
@@ -75,6 +75,6 @@ class FooImpl3 : FooInterface3 {
     override suspend fun run1(value: Int): String = value.toString()
 
     @JsExport.Ignore
-    @JsPromise // asProperty
+    @JsPromise(asProperty = true)
     override suspend fun run2(): String = ""
 }

--- a/tests/test-jvm/build.gradle.kts
+++ b/tests/test-jvm/build.gradle.kts
@@ -41,10 +41,14 @@ dependencies {
     api(kotlin("stdlib"))
     api(kotlin("test-junit5"))
     api(kotlin("reflect"))
+    api(project(":runtime:suspend-transform-annotation"))
+    api(project(":runtime:suspend-transform-runtime"))
     api(libs.kotlinx.coroutines.core)
 }
 
 extensions.getByType<SuspendTransformGradleExtension>().apply {
+    includeRuntime = false
+    includeAnnotation = false
 //     useJvmDefault()
     transformers[TargetPlatform.JVM] = mutableListOf(
         // Add `kotlin.OptIn` to copyAnnotationExcludes


### PR DESCRIPTION
I forgot to add these three attributes to `@JsPromise` before. Now they are added.