### PR TITLE
Added an annotation for function positioning in K2 TargetMarker

### DIFF
--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -11,7 +11,7 @@ object IProject : ProjectDetail() {
 
     // Remember the libs.versions.toml!
     val ktVersion = "2.1.0"
-    val pluginVersion = "0.9.4"
+    val pluginVersion = "0.10.0"
 
     override val version: String = "$ktVersion-$pluginVersion"
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/LocalLoggerHelper.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/LocalLoggerHelper.kt
@@ -1,0 +1,15 @@
+//internal object LocalLoggerHelper {
+//    private val dir = System.getenv("kstcp.logger.dir")
+//    private val path = Path(dir ?: ".plugin-logger") / Path("${System.currentTimeMillis()}.log")
+//    init {
+//        path.parent.createDirectories()
+//        if (path.notExists()) {
+//            path.createFile()
+//        }
+//    }
+//
+//    fun println(value: Any?) {
+//        kotlin.io.println(value)
+//        path.appendText("[${LocalDateTime.now()}] $value\n", Charsets.UTF_8)
+//    }
+//}

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/SuspendTransformConfiguration.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/SuspendTransformConfiguration.kt
@@ -159,6 +159,13 @@ open class SuspendTransformConfiguration {
 
     open var transformers: MutableMap<TargetPlatform, List<Transformer>> = mutableMapOf()
 
+    /**
+     * 在 K2 中，用于使 IR 的合成函数可以定位到 FIR 中原始函数的辅助注解。
+     *
+     * @since *-0.10.0
+     */
+    open var targetMarker: ClassInfo? = targetMarkerClassInfo
+
     open fun clear() {
         transformers.clear()
     }
@@ -217,6 +224,8 @@ open class SuspendTransformConfiguration {
     }
 
     companion object {
+        val targetMarkerClassInfo = ClassInfo("love.forte.plugin.suspendtrans.annotation", "TargetMarker")
+
         //region JVM defaults
         @JvmStatic
         val jvmSyntheticClassInfo = ClassInfo("kotlin.jvm", "JvmSynthetic")

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/ir/SuspendTransformTransformer.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/ir/SuspendTransformTransformer.kt
@@ -92,7 +92,7 @@ class SuspendTransformTransformer(
                     pluginKey,
                     declaration,
                     { f ->
-                        pluginKey.data.originSymbol.checkSame(f)
+                        pluginKey.data.originSymbol.checkSame(pluginKey.data.markerId, f)
                     },
                     callableFunction
                 )?.also { generatedOriginFunction ->
@@ -255,12 +255,14 @@ class SuspendTransformTransformer(
                 originFunction.reportLocation() ?: function.reportLocation()
             )
 
-            function.body = generateTransformBodyForFunctionLambda(
-                pluginContext,
-                function,
-                originFunction,
-                transformTargetFunctionCall
-            )
+            if (function.body == null) {
+                function.body = generateTransformBodyForFunctionLambda(
+                    pluginContext,
+                    function,
+                    originFunction,
+                    transformTargetFunctionCall
+                )
+            }
 
             return originFunction
         }

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/FirUtils.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/FirUtils.kt
@@ -1,0 +1,71 @@
+package love.forte.plugin.suspendtrans.utils
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.expressions.FirEmptyArgumentList
+import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationCall
+import org.jetbrains.kotlin.fir.moduleData
+import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
+import org.jetbrains.kotlin.fir.resolve.defaultType
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.platform.isJs
+import org.jetbrains.kotlin.platform.jvm.isJvm
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
+
+private val jsExportIgnore = ClassId.fromString("kotlin/js/JsExport.Ignore")
+private val jvmSynthetic = ClassId.fromString("kotlin/jvm/JvmSynthetic")
+
+fun FirDeclaration.excludeFromJsExport(session: FirSession) {
+    if (!session.moduleData.platform.isJs()) {
+        return
+    }
+    val jsExportIgnore = session.symbolProvider.getClassLikeSymbolByClassId(jsExportIgnore)
+    val jsExportIgnoreAnnotation = jsExportIgnore as? FirRegularClassSymbol ?: return
+    val jsExportIgnoreConstructor =
+        jsExportIgnoreAnnotation.declarationSymbols.firstIsInstanceOrNull<FirConstructorSymbol>() ?: return
+
+    val jsExportIgnoreAnnotationCall = buildAnnotationCall {
+        argumentList = FirEmptyArgumentList
+        annotationTypeRef = buildResolvedTypeRef {
+            coneType = jsExportIgnoreAnnotation.defaultType()
+        }
+        calleeReference = buildResolvedNamedReference {
+            name = jsExportIgnoreAnnotation.name
+            resolvedSymbol = jsExportIgnoreConstructor
+        }
+
+        containingDeclarationSymbol = this@excludeFromJsExport.symbol
+    }
+
+    replaceAnnotations(annotations + jsExportIgnoreAnnotationCall)
+}
+
+fun FirDeclaration.jvmSynthetic(session: FirSession) {
+    if (!session.moduleData.platform.isJvm()) {
+        return
+    }
+
+    val jvmSynthetic = session.symbolProvider.getClassLikeSymbolByClassId(jvmSynthetic)
+    val jvmExportIgnoreAnnotation = jvmSynthetic as? FirRegularClassSymbol ?: return
+    val jvmExportIgnoreConstructor =
+        jvmExportIgnoreAnnotation.declarationSymbols.firstIsInstanceOrNull<FirConstructorSymbol>() ?: return
+
+    val jvmSyntheticAnnotationCall = buildAnnotationCall {
+        argumentList = FirEmptyArgumentList
+        annotationTypeRef = buildResolvedTypeRef {
+            coneType = jvmExportIgnoreAnnotation.defaultType()
+        }
+        calleeReference = buildResolvedNamedReference {
+            name = jvmExportIgnoreAnnotation.name
+            resolvedSymbol = jvmExportIgnoreConstructor
+        }
+
+        containingDeclarationSymbol = this@jvmSynthetic.symbol
+    }
+
+    replaceAnnotations(annotations + jvmSyntheticAnnotationCall)
+}

--- a/compiler/suspend-transform-plugin/src/test-gen/love/forte/plugin/suspendtrans/runners/CodeGenTestRunnerGenerated.java
+++ b/compiler/suspend-transform-plugin/src/test-gen/love/forte/plugin/suspendtrans/runners/CodeGenTestRunnerGenerated.java
@@ -61,4 +61,10 @@ public class CodeGenTestRunnerGenerated extends AbstractCodeGenTestRunner {
   public void testImplOverridenGeneric() {
     runTest("src/testData/codegen/implOverridenGeneric.kt");
   }
+
+  @Test
+  @TestMetadata("alias.kt")
+  public void testAlias() {
+    runTest("src/testData/codegen/alias.kt");
+  }
 }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/alias.asm.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/alias.asm.txt
@@ -1,0 +1,49 @@
+public final class MainKt : java/lang/Object {
+
+}
+
+final class MyClass$errorReproductionAsync$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final long $amount
+
+    int label
+
+    final MyClass this$0
+
+    void <init>(MyClass $receiver, long $amount, kotlin.coroutines.Continuation p2)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+final class MyClass$errorReproductionBlocking$1 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function1 {
+    final long $amount
+
+    int label
+
+    final MyClass this$0
+
+    void <init>(MyClass $receiver, long $amount, kotlin.coroutines.Continuation p2)
+
+    public final kotlin.coroutines.Continuation create(kotlin.coroutines.Continuation $completion)
+
+    public final java.lang.Object invoke(kotlin.coroutines.Continuation p1)
+
+    public java.lang.Object invoke(java.lang.Object p1)
+
+    public final java.lang.Object invokeSuspend(java.lang.Object $result)
+}
+
+public final class MyClass : java/lang/Object {
+    public void <init>()
+
+    public final java.lang.Object errorReproduction(long amount, kotlin.coroutines.Continuation p1)
+
+    public final java.util.concurrent.CompletableFuture errorReproductionAsync(long amount)
+
+    public final void errorReproductionBlocking(long amount)
+}

--- a/compiler/suspend-transform-plugin/src/testData/codegen/alias.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/alias.fir.ir.txt
@@ -1,0 +1,64 @@
+FILE fqName:<root> fileName:/Main.kt
+  CLASS CLASS name:MyClass modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.MyClass
+    CONSTRUCTOR visibility:public <> () returnType:<root>.MyClass [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:MyClass modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:errorReproductionAsync visibility:public modality:FINAL <> ($this:<root>.MyClass, amount:kotlin.Long) returnType:java.util.concurrent.CompletableFuture
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.MyClass
+      VALUE_PARAMETER name:amount index:0 type:kotlin.Long
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun errorReproductionAsync (amount: kotlin.Long): java.util.concurrent.CompletableFuture declared in <root>.MyClass'
+          CALL 'public final fun $runInAsync$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInAsync$>, scope: kotlinx.coroutines.CoroutineScope?): java.util.concurrent.CompletableFuture declared in love.forte.plugin.suspendtrans.runtime' type=java.util.concurrent.CompletableFuture origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<java.util.concurrent.CompletableFuture> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:java.util.concurrent.CompletableFuture [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): java.util.concurrent.CompletableFuture declared in <root>.MyClass.errorReproductionAsync'
+                    CALL 'public final fun errorReproduction (amount: kotlin.Long): kotlin.Unit declared in <root>.MyClass' type=kotlin.Unit origin=null
+                      $this: GET_VAR '<this>: <root>.MyClass declared in <root>.MyClass.errorReproductionAsync' type=<root>.MyClass origin=null
+                      amount: GET_VAR 'amount: kotlin.Long declared in <root>.MyClass.errorReproductionAsync' type=kotlin.Long origin=null
+    FUN GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:errorReproductionBlocking visibility:public modality:FINAL <> ($this:<root>.MyClass, amount:kotlin.Long) returnType:kotlin.Unit
+      annotations:
+        Api4J
+      $this: VALUE_PARAMETER name:<this> type:<root>.MyClass
+      VALUE_PARAMETER name:amount index:0 type:kotlin.Long
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun errorReproductionBlocking (amount: kotlin.Long): kotlin.Unit declared in <root>.MyClass'
+          CALL 'public final fun $runInBlocking$ <T> (block: kotlin.coroutines.SuspendFunction0<T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$>): T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ declared in love.forte.plugin.suspendtrans.runtime' type=T of love.forte.plugin.suspendtrans.runtime.$runInBlocking$ origin=null
+            <T>: <none>
+            block: FUN_EXPR type=kotlin.coroutines.SuspendFunction0<kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.Unit [suspend]
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.Unit declared in <root>.MyClass.errorReproductionBlocking'
+                    CALL 'public final fun errorReproduction (amount: kotlin.Long): kotlin.Unit declared in <root>.MyClass' type=kotlin.Unit origin=null
+                      $this: GET_VAR '<this>: <root>.MyClass declared in <root>.MyClass.errorReproductionBlocking' type=<root>.MyClass origin=null
+                      amount: GET_VAR 'amount: kotlin.Long declared in <root>.MyClass.errorReproductionBlocking' type=kotlin.Long origin=null
+    FUN name:errorReproduction visibility:public modality:FINAL <> ($this:<root>.MyClass, amount:kotlin.Long) returnType:kotlin.Unit [suspend]
+      annotations:
+        JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZXJyb3JSZXByb2R1Y3Rpb25NeUNsYXNzbnVsbHtNb25leVZhbHVlPX0ga290bGluL0xvbmc=")
+        JvmSynthetic
+      $this: VALUE_PARAMETER name:<this> type:<root>.MyClass
+      VALUE_PARAMETER name:amount index:0 type:kotlin.Long
+      BLOCK_BODY
+        CALL 'public final fun println (message: kotlin.Long): kotlin.Unit declared in kotlin.io' type=kotlin.Unit origin=null
+          message: GET_VAR 'amount: kotlin.Long declared in <root>.MyClass.errorReproduction' type=kotlin.Long origin=null
+  TYPEALIAS name:MoneyValue visibility:public expandedType:kotlin.Long

--- a/compiler/suspend-transform-plugin/src/testData/codegen/alias.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/alias.fir.txt
@@ -1,0 +1,16 @@
+FILE: Main.kt
+    public final typealias MoneyValue = R|kotlin/Long|
+    public final class MyClass : R|kotlin/Any| {
+        public constructor(): R|MyClass| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZXJyb3JSZXByb2R1Y3Rpb25NeUNsYXNzbnVsbHtNb25leVZhbHVlPX0ga290bGluL0xvbmc=)) public final suspend fun errorReproduction(amount: R|{MoneyValue=} kotlin/Long|): R|kotlin/Unit| {
+            R|kotlin/io/println|(R|<local>/amount|)
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public final fun errorReproductionAsync(amount: R|{MoneyValue=} kotlin/Long|): R|java/util/concurrent/CompletableFuture<out kotlin/Unit>|
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public final fun errorReproductionBlocking(amount: R|{MoneyValue=} kotlin/Long|): R|kotlin/Unit|
+
+    }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/alias.kt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/alias.kt
@@ -1,0 +1,16 @@
+// FIR_DUMP
+// DUMP_IR
+// SOURCE
+// FILE: Main.kt [MainKt#main]
+
+import kotlinx.coroutines.runBlocking
+import love.forte.plugin.suspendtrans.annotation.JvmAsync
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
+
+typealias MoneyValue = Long
+
+class MyClass {
+    @JvmBlocking
+    @JvmAsync
+    suspend fun errorReproduction(amount: MoneyValue) { println(amount) }
+}

--- a/compiler/suspend-transform-plugin/src/testData/codegen/asProperty.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/asProperty.fir.ir.txt
@@ -22,6 +22,7 @@ FILE fqName:<root> fileName:/Main.kt
       annotations:
         JvmBlocking(baseName = <null>, suffix = "", asProperty = true)
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = true)
+        TargetMarker(value = "cHJvcFByb3BGb29udWxs")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.PropFoo
       BLOCK_BODY
@@ -86,6 +87,7 @@ FILE fqName:<root> fileName:/Main.kt
       annotations:
         JvmBlocking(baseName = <null>, suffix = "", asProperty = true)
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = true)
+        TargetMarker(value = "cHJvcFByb3BJbXBsbnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun prop (): kotlin.String declared in <root>.IProp
@@ -156,6 +158,7 @@ FILE fqName:<root> fileName:/Main.kt
       annotations:
         JvmBlocking(baseName = <null>, suffix = "", asProperty = true)
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = true)
+        TargetMarker(value = "cHJvcElQcm9wbnVsbA==")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.IProp
     PROPERTY GENERATED[love.forte.plugin.suspendtrans.fir.SuspendTransformPluginKey] name:prop visibility:public modality:OPEN [val]

--- a/compiler/suspend-transform-plugin/src/testData/codegen/asProperty.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/asProperty.fir.txt
@@ -4,7 +4,7 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true), suffix = String()) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(asProperty = Boolean(true)) public final suspend fun prop(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true), suffix = String()) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(asProperty = Boolean(true)) @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(cHJvcFByb3BGb29udWxs)) public final suspend fun prop(): R|kotlin/String| {
             ^prop String()
         }
 
@@ -16,7 +16,7 @@ FILE: Main.kt
 
     }
     public abstract interface IProp : R|kotlin/Any| {
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true), suffix = String()) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(asProperty = Boolean(true)) public abstract suspend fun prop(): R|kotlin/String|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true), suffix = String()) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(asProperty = Boolean(true)) @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(cHJvcElQcm9wbnVsbA==)) public abstract suspend fun prop(): R|kotlin/String|
 
         @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open val prop: R|kotlin/String|
             @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public get(): R|kotlin/String|
@@ -30,7 +30,7 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true), suffix = String()) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(asProperty = Boolean(true)) public open override suspend fun prop(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true), suffix = String()) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(asProperty = Boolean(true)) @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(cHJvcFByb3BJbXBsbnVsbA==)) public open override suspend fun prop(): R|kotlin/String| {
             ^prop String()
         }
 

--- a/compiler/suspend-transform-plugin/src/testData/codegen/basic.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/basic.fir.ir.txt
@@ -51,6 +51,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:bar visibility:public modality:FINAL <> ($this:<root>.BasicBar) returnType:kotlin.String [suspend]
       annotations:
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "YmFyQmFzaWNCYXJudWxs")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.BasicBar
       BLOCK_BODY
@@ -59,6 +60,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:bar2 visibility:public modality:FINAL <> ($this:<root>.BasicBar, i:kotlin.Int) returnType:kotlin.String [suspend]
       annotations:
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "YmFyMkJhc2ljQmFybnVsbGtvdGxpbi9JbnQ=")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.BasicBar
       VALUE_PARAMETER name:i index:0 type:kotlin.Int
@@ -101,6 +103,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:foo visibility:public modality:FINAL <> ($this:<root>.BasicFoo) returnType:kotlin.String [suspend]
       annotations:
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "Zm9vQmFzaWNGb29udWxs")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.BasicFoo
       BLOCK_BODY
@@ -177,11 +180,13 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:bar visibility:public modality:ABSTRACT <> ($this:<root>.InterfaceBar) returnType:kotlin.String [suspend]
       annotations:
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "YmFySW50ZXJmYWNlQmFybnVsbA==")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.InterfaceBar
     FUN name:bar2 visibility:public modality:ABSTRACT <> ($this:<root>.InterfaceBar, i:kotlin.Int) returnType:kotlin.String [suspend]
       annotations:
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "YmFyMkludGVyZmFjZUJhcm51bGxrb3RsaW4vSW50")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.InterfaceBar
       VALUE_PARAMETER name:i index:0 type:kotlin.Int

--- a/compiler/suspend-transform-plugin/src/testData/codegen/basic.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/basic.fir.txt
@@ -4,7 +4,7 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public final suspend fun foo(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(Zm9vQmFzaWNGb29udWxs)) public final suspend fun foo(): R|kotlin/String| {
             ^foo String(foo)
         }
 
@@ -16,11 +16,11 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public final suspend fun bar(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(YmFyQmFzaWNCYXJudWxs)) public final suspend fun bar(): R|kotlin/String| {
             ^bar String(bar)
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public final suspend fun bar2(i: R|kotlin/Int|): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(YmFyMkJhc2ljQmFybnVsbGtvdGxpbi9JbnQ=)) public final suspend fun bar2(i: R|kotlin/Int|): R|kotlin/String| {
             ^bar2 String(bar2)
         }
 
@@ -30,9 +30,9 @@ FILE: Main.kt
 
     }
     public abstract interface InterfaceBar : R|kotlin/Any| {
-        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public abstract suspend fun bar(): R|kotlin/String|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(YmFySW50ZXJmYWNlQmFybnVsbA==)) public abstract suspend fun bar(): R|kotlin/String|
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public abstract suspend fun bar2(i: R|kotlin/Int|): R|kotlin/String|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(YmFyMkludGVyZmFjZUJhcm51bGxrb3RsaW4vSW50)) public abstract suspend fun bar2(i: R|kotlin/Int|): R|kotlin/String|
 
         public abstract fun asyncBase(i: R|kotlin/Int|): R|ResultValue<out kotlin/String>|
 

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.fir.ir.txt
@@ -67,6 +67,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTFJbXBsbnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun data (): kotlin.String declared in <root>.FooInterface1
@@ -77,6 +78,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl, value:kotlin.Int) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2UxSW1wbG51bGxrb3RsaW4vSW50")
         JvmSynthetic
       overridden:
         public abstract fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface1
@@ -88,6 +90,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl, $receiver:kotlin.Int) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTNGb29JbnRlcmZhY2UxSW1wbGtvdGxpbi9JbnQ=")
         JvmSynthetic
       overridden:
         public abstract fun data3 (): kotlin.String declared in <root>.FooInterface1
@@ -170,6 +173,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTJJbXBsbnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun data (): kotlin.String declared in <root>.FooInterface2
@@ -180,6 +184,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl, value:kotlin.Int) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2UySW1wbG51bGxrb3RsaW4vSW50")
         JvmSynthetic
       overridden:
         public abstract fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface2
@@ -191,6 +196,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl, $receiver:kotlin.Int) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTNGb29JbnRlcmZhY2UySW1wbGtvdGxpbi9JbnQ=")
         JvmSynthetic
       overridden:
         public abstract fun data3 (): kotlin.String declared in <root>.FooInterface2
@@ -221,6 +227,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = true)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTNJbXBsbnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun data (): kotlin.String declared in <root>.FooInterface3
@@ -306,6 +313,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTRJbXBsbnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun data (): kotlin.String declared in <root>.FooInterface4
@@ -316,6 +324,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl, value:kotlin.Int) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2U0SW1wbG51bGxrb3RsaW4vSW50")
         JvmSynthetic
       overridden:
         public abstract fun data2 (value: kotlin.Int): kotlin.String declared in <root>.FooInterface4
@@ -459,11 +468,13 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTRudWxs")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4
     FUN name:data2 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4, value:kotlin.Int) returnType:kotlin.String [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2U0bnVsbGtvdGxpbi9JbnQ=")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4
       VALUE_PARAMETER name:value index:0 type:kotlin.Int

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverriden.fir.txt
@@ -12,15 +12,15 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTFJbXBsbnVsbA==)) public open override suspend fun data(): R|kotlin/String| {
             ^data String()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2UxSW1wbG51bGxrb3RsaW4vSW50)) public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
             ^data2 String()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTNGb29JbnRlcmZhY2UxSW1wbGtvdGxpbi9JbnQ=)) public open override suspend fun R|kotlin/Int|.data3(): R|kotlin/String| {
             ^data3 String()
         }
 
@@ -56,15 +56,15 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTJJbXBsbnVsbA==)) public open override suspend fun data(): R|kotlin/String| {
             ^data String()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2UySW1wbG51bGxrb3RsaW4vSW50)) public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
             ^data2 String()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTNGb29JbnRlcmZhY2UySW1wbGtvdGxpbi9JbnQ=)) public open override suspend fun R|kotlin/Int|.data3(): R|kotlin/String| {
             ^data3 String()
         }
 
@@ -89,7 +89,7 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true)) public open override suspend fun data(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(asProperty = Boolean(true)) @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTNJbXBsbnVsbA==)) public open override suspend fun data(): R|kotlin/String| {
             ^data String()
         }
 
@@ -98,9 +98,9 @@ FILE: Main.kt
 
     }
     public abstract interface FooInterface4 : R|kotlin/Any| {
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data(): R|kotlin/String|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTRudWxs)) public abstract suspend fun data(): R|kotlin/String|
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data2(value: R|kotlin/Int|): R|kotlin/String|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2U0bnVsbGtvdGxpbi9JbnQ=)) public abstract suspend fun data2(value: R|kotlin/Int|): R|kotlin/String|
 
         @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun data2Blocking(value: R|kotlin/Int|): R|kotlin/String|
 
@@ -112,11 +112,11 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTRJbXBsbnVsbA==)) public open override suspend fun data(): R|kotlin/String| {
             ^data String()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2U0SW1wbG51bGxrb3RsaW4vSW50)) public open override suspend fun data2(value: R|kotlin/Int|): R|kotlin/String| {
             ^data2 String()
         }
 

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.fir.ir.txt
@@ -70,6 +70,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>) returnType:T of <root>.FooInterface1Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTFJbXBsPFQ+bnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun data (): T of <root>.FooInterface1 declared in <root>.FooInterface1
@@ -80,6 +81,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data2 visibility:public modality:OPEN <A> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>, value:A of <root>.FooInterface1Impl.data2) returnType:T of <root>.FooInterface1Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2UxSW1wbDxUPm51bGxB")
         JvmSynthetic
       overridden:
         public abstract fun data2 <A> (value: A of <root>.FooInterface1.data2): T of <root>.FooInterface1 declared in <root>.FooInterface1
@@ -92,6 +94,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface1Impl<T of <root>.FooInterface1Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface1Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTNGb29JbnRlcmZhY2UxSW1wbDxUPmtvdGxpbi9JbnQ=")
         JvmSynthetic
       overridden:
         public abstract fun data3 (): T of <root>.FooInterface1 declared in <root>.FooInterface1
@@ -169,6 +172,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>) returnType:T of <root>.FooInterface2Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTJJbXBsPFQ+bnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun data (): T of <root>.FooInterface2 declared in <root>.FooInterface2
@@ -179,6 +183,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>, value:T of <root>.FooInterface2Impl) returnType:T of <root>.FooInterface2Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2UySW1wbDxUPm51bGxU")
         JvmSynthetic
       overridden:
         public abstract fun data2 (value: T of <root>.FooInterface2): T of <root>.FooInterface2 declared in <root>.FooInterface2
@@ -190,6 +195,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface2Impl<T of <root>.FooInterface2Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface2Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTNGb29JbnRlcmZhY2UySW1wbDxUPmtvdGxpbi9JbnQ=")
         JvmSynthetic
       overridden:
         public abstract fun data3 (): T of <root>.FooInterface2 declared in <root>.FooInterface2
@@ -275,6 +281,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>) returnType:T of <root>.FooInterface3Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTNJbXBsPFQ+bnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun data (): T of <root>.FooInterface3 declared in <root>.FooInterface3
@@ -285,6 +292,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data2 visibility:public modality:OPEN <A> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>, value:A of <root>.FooInterface3Impl.data2) returnType:T of <root>.FooInterface3Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2UzSW1wbDxUPm51bGxB")
         JvmSynthetic
       overridden:
         public abstract fun data2 <A> (value: A of <root>.FooInterface3.data2): T of <root>.FooInterface3 declared in <root>.FooInterface3
@@ -297,6 +305,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface3Impl<T of <root>.FooInterface3Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface3Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTNGb29JbnRlcmZhY2UzSW1wbDxUPmtvdGxpbi9JbnQ=")
         JvmSynthetic
       overridden:
         public abstract fun data3 (): T of <root>.FooInterface3 declared in <root>.FooInterface3
@@ -380,6 +389,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>) returnType:T of <root>.FooInterface4Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTRJbXBsPFQ+bnVsbA==")
         JvmSynthetic
       overridden:
         public abstract fun data (): T of <root>.FooInterface4 declared in <root>.FooInterface4
@@ -390,6 +400,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data2 visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>, value:T of <root>.FooInterface4Impl) returnType:T of <root>.FooInterface4Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2U0SW1wbDxUPm51bGxU")
         JvmSynthetic
       overridden:
         public abstract fun data2 (value: T of <root>.FooInterface4): T of <root>.FooInterface4 declared in <root>.FooInterface4
@@ -401,6 +412,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data3 visibility:public modality:OPEN <> ($this:<root>.FooInterface4Impl<T of <root>.FooInterface4Impl>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface4Impl [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTNGb29JbnRlcmZhY2U0SW1wbDxUPmtvdGxpbi9JbnQ=")
         JvmSynthetic
       overridden:
         public abstract fun data3 (): T of <root>.FooInterface4 declared in <root>.FooInterface4
@@ -555,11 +567,13 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface3<T of <root>.FooInterface3>) returnType:T of <root>.FooInterface3 [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTM8VD5udWxs")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
     FUN name:data2 visibility:public modality:ABSTRACT <A> ($this:<root>.FooInterface3<T of <root>.FooInterface3>, value:A of <root>.FooInterface3.data2) returnType:T of <root>.FooInterface3 [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2UzPFQ+bnVsbEE=")
         JvmSynthetic
       TYPE_PARAMETER name:A index:0 variance: superTypes:[kotlin.Any?] reified:false
       $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
@@ -567,6 +581,7 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data3 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface3<T of <root>.FooInterface3>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface3 [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTNGb29JbnRlcmZhY2UzPFQ+a290bGluL0ludA==")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface3<T of <root>.FooInterface3>
       $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int
@@ -635,17 +650,20 @@ FILE fqName:<root> fileName:/Main.kt
     FUN name:data visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>) returnType:T of <root>.FooInterface4 [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YUZvb0ludGVyZmFjZTQ8VD5udWxs")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
     FUN name:data2 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>, value:T of <root>.FooInterface4) returnType:T of <root>.FooInterface4 [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTJGb29JbnRlcmZhY2U0PFQ+bnVsbFQ=")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
       VALUE_PARAMETER name:value index:0 type:T of <root>.FooInterface4
     FUN name:data3 visibility:public modality:ABSTRACT <> ($this:<root>.FooInterface4<T of <root>.FooInterface4>, $receiver:kotlin.Int) returnType:T of <root>.FooInterface4 [suspend]
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "ZGF0YTNGb29JbnRlcmZhY2U0PFQ+a290bGluL0ludA==")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.FooInterface4<T of <root>.FooInterface4>
       $receiver: VALUE_PARAMETER name:<this> type:kotlin.Int

--- a/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/implOverridenGeneric.fir.txt
@@ -16,15 +16,15 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTFJbXBsPFQ+bnVsbA==)) public open override suspend fun data(): R|T| {
             ^data R|kotlin/TODO|()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun <A> data2(value: R|A|): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2UxSW1wbDxUPm51bGxB)) public open override suspend fun <A> data2(value: R|A|): R|T| {
             ^data2 R|kotlin/TODO|()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTNGb29JbnRlcmZhY2UxSW1wbDxUPmtvdGxpbi9JbnQ=)) public open override suspend fun R|kotlin/Int|.data3(): R|T| {
             ^data3 R|kotlin/TODO|()
         }
 
@@ -48,15 +48,15 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTJJbXBsPFQ+bnVsbA==)) public open override suspend fun data(): R|T| {
             ^data R|kotlin/TODO|()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|T|): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2UySW1wbDxUPm51bGxU)) public open override suspend fun data2(value: R|T|): R|T| {
             ^data2 R|kotlin/TODO|()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTNGb29JbnRlcmZhY2UySW1wbDxUPmtvdGxpbi9JbnQ=)) public open override suspend fun R|kotlin/Int|.data3(): R|T| {
             ^data3 R|kotlin/TODO|()
         }
 
@@ -68,11 +68,11 @@ FILE: Main.kt
 
     }
     public abstract interface FooInterface3<T : R|Foo|> : R|kotlin/Any| {
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data(): R|T|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTM8VD5udWxs)) public abstract suspend fun data(): R|T|
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun <A> data2(value: R|A|): R|T|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2UzPFQ+bnVsbEE=)) public abstract suspend fun <A> data2(value: R|A|): R|T|
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun R|kotlin/Int|.data3(): R|T|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTNGb29JbnRlcmZhY2UzPFQ+a290bGluL0ludA==)) public abstract suspend fun R|kotlin/Int|.data3(): R|T|
 
         @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun <A> data2Blocking(value: R|A|): R|T|
 
@@ -86,15 +86,15 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTNJbXBsPFQ+bnVsbA==)) public open override suspend fun data(): R|T| {
             ^data R|kotlin/TODO|()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun <A> data2(value: R|A|): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2UzSW1wbDxUPm51bGxB)) public open override suspend fun <A> data2(value: R|A|): R|T| {
             ^data2 R|kotlin/TODO|()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTNGb29JbnRlcmZhY2UzSW1wbDxUPmtvdGxpbi9JbnQ=)) public open override suspend fun R|kotlin/Int|.data3(): R|T| {
             ^data3 R|kotlin/TODO|()
         }
 
@@ -106,11 +106,11 @@ FILE: Main.kt
 
     }
     public abstract interface FooInterface4<T : R|Foo|> : R|kotlin/Any| {
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data(): R|T|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTQ8VD5udWxs)) public abstract suspend fun data(): R|T|
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun data2(value: R|T|): R|T|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2U0PFQ+bnVsbFQ=)) public abstract suspend fun data2(value: R|T|): R|T|
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public abstract suspend fun R|kotlin/Int|.data3(): R|T|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTNGb29JbnRlcmZhY2U0PFQ+a290bGluL0ludA==)) public abstract suspend fun R|kotlin/Int|.data3(): R|T|
 
         @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun data2Blocking(value: R|T|): R|T|
 
@@ -124,15 +124,15 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data(): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YUZvb0ludGVyZmFjZTRJbXBsPFQ+bnVsbA==)) public open override suspend fun data(): R|T| {
             ^data R|kotlin/TODO|()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun data2(value: R|T|): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTJGb29JbnRlcmZhY2U0SW1wbDxUPm51bGxU)) public open override suspend fun data2(value: R|T|): R|T| {
             ^data2 R|kotlin/TODO|()
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() public open override suspend fun R|kotlin/Int|.data3(): R|T| {
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(ZGF0YTNGb29JbnRlcmZhY2U0SW1wbDxUPmtvdGxpbi9JbnQ=)) public open override suspend fun R|kotlin/Int|.data3(): R|T| {
             ^data3 R|kotlin/TODO|()
         }
 

--- a/compiler/suspend-transform-plugin/src/testData/codegen/opt.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/opt.fir.ir.txt
@@ -106,6 +106,7 @@ FILE fqName:<root> fileName:/Main.kt
         Values(target = CLASS_REFERENCE 'CLASS CLASS name:OptInTest modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.OptInTest>)
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "cnVuT3B0SW5UZXN0bnVsbA==")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.OptInTest
       BLOCK_BODY

--- a/compiler/suspend-transform-plugin/src/testData/codegen/opt.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/opt.fir.txt
@@ -23,7 +23,7 @@ FILE: Main.kt
             ^run0 Int(1)
         }
 
-        @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|OneOptAnno|))) @R|Values|(target = <getClass>(Q|OptInTest|)) @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public final suspend fun run(): R|kotlin/Int| {
+        @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|OneOptAnno|))) @R|Values|(target = <getClass>(Q|OptInTest|)) @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(cnVuT3B0SW5UZXN0bnVsbA==)) public final suspend fun run(): R|kotlin/Int| {
             ^run this@R|/OptInTest|.R|/OptInTest.run0|()
         }
 

--- a/compiler/suspend-transform-plugin/src/testData/codegen/override.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/override.fir.ir.txt
@@ -166,6 +166,7 @@ FILE fqName:<root> fileName:/Main.kt
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "cnVuRm9vbnVsbA==")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.Foo
     FUN name:run visibility:public modality:ABSTRACT <> ($this:<root>.Foo, n:kotlin.Int) returnType:<root>.Bar [suspend]
@@ -231,6 +232,7 @@ FILE fqName:<root> fileName:/Main.kt
                       n: GET_VAR 'n: kotlin.Int declared in <root>.IFoo.runBlocking' type=kotlin.Int origin=null
     FUN name:run visibility:public modality:ABSTRACT <> ($this:<root>.IFoo, n:kotlin.Int) returnType:<root>.Bar [suspend]
       annotations:
+        TargetMarker(value = "cnVuSUZvb251bGxrb3RsaW4vSW50")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.IFoo
       VALUE_PARAMETER name:n index:0 type:kotlin.Int

--- a/compiler/suspend-transform-plugin/src/testData/codegen/override.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/override.fir.txt
@@ -1,6 +1,6 @@
 FILE: Main.kt
     @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public abstract interface IFoo : R|kotlin/Any| {
-        public abstract suspend fun run(n: R|kotlin/Int|): R|Bar|
+        @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(cnVuSUZvb251bGxrb3RsaW4vSW50)) public abstract suspend fun run(n: R|kotlin/Int|): R|Bar|
 
         @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun runAsync(n: R|kotlin/Int|): R|java/util/concurrent/CompletableFuture<out Bar>|
 
@@ -8,7 +8,7 @@ FILE: Main.kt
 
     }
     public abstract interface Foo : R|IFoo| {
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public abstract suspend fun run(): R|Bar|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(cnVuRm9vbnVsbA==)) public abstract suspend fun run(): R|Bar|
 
         public open suspend fun run(name: R|kotlin/String|): R|Tar| {
             ^run R|/Tar.Tar|()

--- a/compiler/suspend-transform-plugin/src/testData/codegen/typeAttr.fir.ir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/typeAttr.fir.ir.txt
@@ -204,6 +204,7 @@ FILE fqName:<root> fileName:/Main.kt
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "cnVuRm9vPFQ+bnVsbEFwaTxSPg==")
         JvmSynthetic
       TYPE_PARAMETER name:R index:0 variance: superTypes:[kotlin.Any] reified:false
       $this: VALUE_PARAMETER name:<this> type:<root>.Foo<T of <root>.Foo>
@@ -212,5 +213,6 @@ FILE fqName:<root> fileName:/Main.kt
       annotations:
         JvmBlocking(baseName = <null>, suffix = <null>, asProperty = <null>)
         JvmAsync(baseName = <null>, suffix = <null>, asProperty = <null>)
+        TargetMarker(value = "dmFsdWVGb288VD5udWxs")
         JvmSynthetic
       $this: VALUE_PARAMETER name:<this> type:<root>.Foo<T of <root>.Foo>

--- a/compiler/suspend-transform-plugin/src/testData/codegen/typeAttr.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/typeAttr.fir.txt
@@ -18,9 +18,9 @@ FILE: Main.kt
 
     }
     public abstract interface Foo<out T : R|Bar|> : R|kotlin/Any| {
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public abstract suspend fun value(): R|T|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(dmFsdWVGb288VD5udWxs)) public abstract suspend fun value(): R|T|
 
-        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() public abstract suspend fun <R : R|kotlin/Any|> run(api: R|Api<R>|): R|R|
+        @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|() @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|() @R|love/forte/plugin/suspendtrans/annotation/TargetMarker|(value = String(cnVuRm9vPFQ+bnVsbEFwaTxSPg==)) public abstract suspend fun <R : R|kotlin/Any|> run(api: R|Api<R>|): R|R|
 
         @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public open fun valueAsync(): R|java/util/concurrent/CompletableFuture<out T>|
 

--- a/runtime/suspend-transform-annotation/src/commonMain/kotlin/love/forte/plugin/suspendtrans/annotation/TargetMarker.kt
+++ b/runtime/suspend-transform-annotation/src/commonMain/kotlin/love/forte/plugin/suspendtrans/annotation/TargetMarker.kt
@@ -1,0 +1,11 @@
+package love.forte.plugin.suspendtrans.annotation
+
+/**
+ * @since *-0.10.0
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Deprecated("Only used by auto-generate", level = DeprecationLevel.HIDDEN)
+@Repeatable
+public annotation class TargetMarker(
+    val value: String
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,3 +30,4 @@ include(":plugins:suspend-transform-plugin-gradle")
 //Samples
 // include(":tests:test-jvm")
 // include(":tests:test-js")
+include(":tests:test-kmp")

--- a/tests/test-kmp/build.gradle.kts
+++ b/tests/test-kmp/build.gradle.kts
@@ -1,0 +1,76 @@
+import love.forte.plugin.suspendtrans.ClassInfo
+import love.forte.plugin.suspendtrans.SuspendTransformConfiguration.Companion.jvmAsyncTransformer
+import love.forte.plugin.suspendtrans.SuspendTransformConfiguration.Companion.jvmBlockingTransformer
+import love.forte.plugin.suspendtrans.TargetPlatform
+import love.forte.plugin.suspendtrans.gradle.SuspendTransformGradleExtension
+
+plugins {
+    kotlin("multiplatform")
+}
+
+
+buildscript {
+    this@buildscript.repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-0.10.0")
+    }
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xjvm-default=all")
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+}
+
+repositories {
+    mavenLocal()
+}
+
+apply(plugin = "love.forte.plugin.suspend-transform")
+
+kotlin {
+    jvm()
+    js {
+        nodejs()
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(kotlin("reflect"))
+            implementation(project(":runtime:suspend-transform-annotation"))
+            implementation(project(":runtime:suspend-transform-runtime"))
+            implementation(libs.kotlinx.coroutines.core)
+        }
+    }
+}
+
+extensions.getByType<SuspendTransformGradleExtension>().apply {
+    includeRuntime = false
+    includeAnnotation = false
+//     useJvmDefault()
+    transformers[TargetPlatform.JVM] = mutableListOf(
+        // Add `kotlin.OptIn` to copyAnnotationExcludes
+        jvmBlockingTransformer.copy(
+            copyAnnotationExcludes = buildList {
+                addAll(jvmBlockingTransformer.copyAnnotationExcludes)
+                add(ClassInfo("kotlin", "OptIn"))
+            }
+        ),
+
+        // Add `kotlin.OptIn` to copyAnnotationExcludes
+        jvmAsyncTransformer.copy(
+            copyAnnotationExcludes = buildList {
+                addAll(jvmAsyncTransformer.copyAnnotationExcludes)
+                add(ClassInfo("kotlin", "OptIn"))
+            }
+        )
+    )
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/tests/test-kmp/src/commonMain/kotlin/example/MyClass.kt
+++ b/tests/test-kmp/src/commonMain/kotlin/example/MyClass.kt
@@ -1,0 +1,10 @@
+package example
+
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
+
+expect class MoneyValue
+
+class MyClass {
+    @JvmBlocking
+    suspend fun errorReproduction(amount: MoneyValue) = println(amount)
+}

--- a/tests/test-kmp/src/jsMain/kotlin/example/MyClass.js.kt
+++ b/tests/test-kmp/src/jsMain/kotlin/example/MyClass.js.kt
@@ -1,0 +1,3 @@
+package example
+
+actual class MoneyValue

--- a/tests/test-kmp/src/jvmMain/kotlin/example/MyClass.jvm.kt
+++ b/tests/test-kmp/src/jvmMain/kotlin/example/MyClass.jvm.kt
@@ -1,0 +1,5 @@
+package example
+
+import java.math.BigDecimal
+
+actual typealias MoneyValue = BigDecimal


### PR DESCRIPTION
Added an annotation for function positioning in K2: `TargetMarker` .

It is defined in the `annotation` module and can be customised through configuration item `targetMarker`.

```kotlin
suspendTransform {
    targetMarker = ClassInfo(...)
}
```

**What it does**

Previously, in K2 mode, to generate a _bridge function_ for a pending function, you needed to generate the symbol of the bridge function in the FIR stage and then generate the Body of the bridge function in the IR stage.

In the IR stage I need to know who the source function corresponding to the bridge function is. 
But the source function is located in the FIR stage, so we need to pass some uniquely located information about the source function with the help of `PluginKey`, which includes its function name and a list of the parameter types. (I haven't found a safe, direct way to determine whether FIR and IR are the same by using `==`)

Previously, this solution was basically possible because the function name and the list of types could identify a unique function.

But this does not work in the case of #72.

The combination of `expect/actual` and `typealias` is used in #72. At the FIR stage, the `MoneyValue` is always `MoneyValue` type, and since it's expected, I've never been able to find out how to get its real type, whether it's actual or typealias. I tried a number of ways, such as `expectForActual`, `memberExpectForActual`, `fullyExpandedType`, and other seemingly related functions I could find. But they either get `MoneyValue` itself or `null`, there is no available solution. 
As for other options, after all, KCP is not fully documented and I can't get started at the moment.

And after the FIR, in the IR stage, `MoneyValue` has completely changed to `BigDecimal`, which is why it is impossible to locate the source function: the FIR stage and the IR stage, the same function has a different parameter type.

| FIR | match | IR |
| ---- | ---- | ---- |
| `errorReproduction` | ---✔--- | `errorReproduction` |
| \\- [0]`MoneyValue` | ---❓--- | \\- [0]`java.math.BigDecimal` |


**How to fix**

Rather than fixing it, I think it's more like circumventing the problem outright. Since I can't locate the source function via the argument type list, I'll just locate it in a different way.

The new annotation `TargetMarket` does just that. In the FIR stage, a unique ID is generated from the function name and the list of parameter types (that's the base64 string with the name and type spliced in order)

Mark this ID and annotation on the source function. Then, only this ID is passed to the IR, not the list of types. Afterwards, in the IR stage, only the function with a matching value needs to be found.

| FIR | ID |match | ID to look for | IR |
| ---- | ---- | ---- | ---- | ---- |
| `errorReproduction(MoneyValue)` | `abcd1234` | ---✔--- | `abcd1234` | `errorReproduction(BigDecimal)` |


**caution**

By default, `targetMarker` is specified as an annotation `TargetMarker` in the `annotation` module. 
When the `targetMarker` annotation is specified, there will be no matching based on other ways. So please note that if you customise an `targetMarker` annotation and it is not available, or if you disable references to the `annotation` module (`includeAnnotation = false`), this may cause problems.

If you specify `targetMarker` as `null`, then the matching is done using the original scheme: using the function name and argument type list.

```kotlin
suspendTransform {
    targetMarker = null
}
```

_It's not clear to me at the moment if there's a better solution to the problem of finding some function from IR that is identified in FIR, or to the problem of `expect/actual`+`typealias`._

resolve #72 
