### PR TITLE
If the TargetMarker match is unsuccessful, then continue with the original logic.

### DIFF
--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -11,7 +11,7 @@ object IProject : ProjectDetail() {
 
     // Remember the libs.versions.toml!
     val ktVersion = "2.1.0"
-    val pluginVersion = "0.10.0"
+    val pluginVersion = "0.10.1"
 
     override val version: String = "$ktVersion-$pluginVersion"
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/SuspendTransformUserData.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/SuspendTransformUserData.kt
@@ -277,10 +277,13 @@ private fun FirValueParameter.toValueParameter(session: FirSession, index: Int):
 fun OriginSymbol.checkSame(markerId: String, declaration: IrFunction): Boolean {
     if (targetMarker != null) {
         val anno = declaration.annotations.firstOrNull { it.symbol.owner.parentAsClass.classId == targetMarker }
-        if (anno == null) return false
-
-        val valueArgument = anno.getValueArgument(Name.identifier("value")) as? IrConst ?: return false
-        return markerId == valueArgument.value
+        if (anno != null) {
+            val valueArgument = anno.getValueArgument(Name.identifier("value")) as? IrConst
+            if (markerId == valueArgument?.value) {
+                return true
+            }
+        }
+        // 如果匹配不成功，继续原本的逻辑
     }
 
     // callableId


### PR DESCRIPTION
In #73 we added `TargetMarker`, but it will simply block the old logic if it takes effect. 

However, we seem to have found some difficult to reproduce and strange problems.

Now, regardless of whether the `TargetMarker` doesn't exist or the match fails, it reverts to the original logic and continues matching.

In the future, we intend to change the logic and optimise efficiency with #75 