### PR TITLE
Fix: Parent Job is Cancelled

### DIFF
--- a/runtime/suspend-transform-runtime/src/jsMain/kotlin/love.forte.plugin.suspendtrans/runtime/RunInSuspendJs.kt
+++ b/runtime/suspend-transform-runtime/src/jsMain/kotlin/love.forte.plugin.suspendtrans/runtime/RunInSuspendJs.kt
@@ -5,8 +5,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.promise
 import kotlin.coroutines.CoroutineContext
 import kotlin.js.Promise
+import kotlinx.coroutines.SupervisorJob
 
-private val CoroutineContext4Js: CoroutineContext = Dispatchers.Default
+private val CoroutineContext4Js: CoroutineContext = Dispatchers.Default + SupervisorJob()
 
 private val CoroutineScope4Js: CoroutineScope = CoroutineScope(CoroutineContext4Js)
 


### PR DESCRIPTION
When using the plugin, I ran into a problem: when executing http requests to js in the suspend methods generated by the plugin, if there was any unprocessed error that led to the termination of the child job of the root, this led to the termination of all other jobs in this context. After that, when calling the same method, it threw an error: Parent Job is Cancelled. Using supervisor job in context helped me.

In Kotlin, a supervised coroutine scope is typically created to ensure that the failure of a child coroutine does not automatically cancel its sibling coroutines. This can be useful for specific structured concurrency needs.

Here’s how you can achieve a supervised coroutine scope:

1. Use `SupervisorJob` with your CoroutineScope  
   A SupervisorJob allows for the creation of a coroutine scope where child coroutines fail independently.

2. Create a scope with `SupervisorJob`  
   You can create a CoroutineScope using a SupervisorJob combined with a Dispatcher (like Dispatchers.Default or `Dispatchers.IO`).
