### PR TITLE
Improved logic for Gradle plugin dependency including and advance `enable` detection

### DIFF
--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -11,7 +11,7 @@ object IProject : ProjectDetail() {
 
     // Remember the libs.versions.toml!
     val ktVersion = "2.1.0"
-    val pluginVersion = "0.11.0"
+    val pluginVersion = "0.11.1"
 
     override val version: String = "$ktVersion-$pluginVersion"
 

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/CliOptions.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/CliOptions.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.json.Json
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
-import kotlin.reflect.KMutableProperty
 
 private val defaultJson = Json {
     isLenient = true
@@ -84,15 +83,15 @@ private class ResolveBuilder {
         outc = block
     }
 
-    fun withProp(block: SuspendTransformConfiguration.() -> KMutableProperty<String>) {
-        inc { block().setter.call(it) }
-        out { block().getter.call() }
-    }
-
-    fun withNullableProp(block: SuspendTransformConfiguration.() -> KMutableProperty<String?>) {
-        inc { block().setter.call(it.takeIf { it.isNotEmpty() }) }
-        out { block().getter.call() ?: "" }
-    }
+//    fun withProp(block: SuspendTransformConfiguration.() -> KMutableProperty<String>) {
+//        inc { block().setter.call(it) }
+//        out { block().getter.call() }
+//    }
+//
+//    fun withNullableProp(block: SuspendTransformConfiguration.() -> KMutableProperty<String?>) {
+//        inc { block().setter.call(it.takeIf { it.isNotEmpty() }) }
+//        out { block().getter.call() ?: "" }
+//    }
 }
 
 private fun option(

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/TransformUtil.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/TransformUtil.kt
@@ -11,5 +11,6 @@ import org.jetbrains.kotlin.name.Name
 fun ClassInfo.toClassId(): ClassId =
     ClassId(packageName.fqn, className.fqn, local)
 
+@Suppress("DEPRECATION")
 fun FunctionInfo.toCallableId(): CallableId =
     CallableId(packageName.fqn, className?.fqn, Name.identifier(functionName))

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,6 @@ org.gradle.jvmargs=-Xmx8G -Xms2G -XX:MaxMetaspaceSize=1G -Dfile.encoding=UTF-8
 #Development
 #development=true
 #kotlin.js.ir.output.granularity=per-file
+
+# https://kotlinlang.org/docs/multiplatform-publish-lib.html#host-requirements
+#kotlin.native.enableKlibsCrossCompilation=true

--- a/plugins/suspend-transform-plugin-gradle/src/main/kotlin/love/forte/plugin/suspendtrans/gradle/SuspendTransformGradlePlugin.kt
+++ b/plugins/suspend-transform-plugin-gradle/src/main/kotlin/love/forte/plugin/suspendtrans/gradle/SuspendTransformGradlePlugin.kt
@@ -69,6 +69,15 @@ private fun SuspendTransformGradleExtension.toSubpluginOptions(): List<Subplugin
 
 private fun Project.configureDependencies() {
     fun Project.include(platform: Platform, conf: SuspendTransformGradleExtension) {
+        if (!conf.enabled) {
+            logger.info(
+                "The `SuspendTransformGradleExtension.enable` in project {} for platform {} is `false`, skip config.",
+                this,
+                platform
+            )
+            return
+        }
+
         if (conf.includeAnnotation) {
             val notation = getDependencyNotation(
                 SuspendTransPluginConstants.ANNOTATION_GROUP,
@@ -79,7 +88,7 @@ private fun Project.configureDependencies() {
             if (platform == Platform.JVM) {
                 dependencies.add(conf.annotationConfigurationName, notation)
             } else {
-                // JS, native 似乎不支持其他的 name，例如 compileOnly
+                // JS, native 似乎不支持 compileOnly
                 dependencies.add("implementation", notation)
             }
             dependencies.add("testImplementation", notation)
@@ -137,6 +146,7 @@ private enum class DependencyConfigurationName {
 }
 
 fun Project.configureMultiplatformDependency(conf: SuspendTransformGradleExtension) {
+    // 时间久远，已经忘记为什么要做这个判断了，也忘记这段是在哪儿参考来的了💀
     if (rootProject.getBooleanProperty("kotlin.mpp.enableGranularSourceSetsMetadata")) {
         val multiplatformExtensions = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
 
@@ -202,16 +212,14 @@ fun Project.configureMultiplatformDependency(conf: SuspendTransformGradleExtensi
     } else {
         sourceSetsByCompilation().forEach { (sourceSet, compilations) ->
             val platformTypes = compilations.map { it.platformType }.toSet()
-            logger.info("platformTypes: {}", platformTypes)
+            logger.info(
+                "Configure sourceSet [{}]. compilations: {}, platformTypes: {}",
+                sourceSet,
+                compilations,
+                platformTypes
+            )
 
-//            val compilationNames = compilations.map { it.compilationName }.toSet()
-//            logger.info("compilationNames: {}", compilationNames)
-//
-//            if (compilationNames.size != 1) {
-//                // TODO error or warn or nothing?
-//                //error("Source set '${sourceSet.name}' of project '$name' is part of several compilations $compilationNames")
-//            }
-
+            // TODO 可能同一个 sourceSet 会出现重复，但是需要处理吗？
             for (compilation in compilations) {
                 val platformType = compilation.platformType
                 val compilationName = compilation.compilationName
@@ -271,6 +279,12 @@ fun Project.configureMultiplatformDependency(conf: SuspendTransformGradleExtensi
                     }
 
                     // dependencies.add(configurationName, notation)
+                    logger.debug(
+                        "Add annotation dependency: {} {} for sourceSet {}",
+                        configurationName,
+                        notation,
+                        sourceSet
+                    )
                 }
 
                 if (conf.includeRuntime) {
@@ -285,7 +299,13 @@ fun Project.configureMultiplatformDependency(conf: SuspendTransformGradleExtensi
                     sourceSet.dependencies {
                         implementation(notation)
                     }
-                    // dependencies.add(configurationName, notation)
+
+                    logger.debug(
+                        "Add runtime dependency: {} {} for sourceSet {}",
+                        IMPLEMENTATION,
+                        notation,
+                        sourceSet
+                    )
                 }
             }
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include(":plugins:suspend-transform-plugin-gradle")
 // include(":local-helper")
 
 //Samples
-// include(":tests:test-jvm")
-// include(":tests:test-js")
-// include(":tests:test-kmp")
+ include(":tests:test-jvm")
+ include(":tests:test-js")
+ include(":tests:test-kmp")
+// include(":tests:test-android")

--- a/tests/test-android/build.gradle.kts
+++ b/tests/test-android/build.gradle.kts
@@ -1,0 +1,78 @@
+import jdk.tools.jlink.resources.plugins
+
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+    id("com.android.library") version "8.8.0"
+    id("maven-publish")
+    // id("com.github.ben-manes.versions")
+    // id("love.forte.plugin.suspend-transform")
+}
+
+buildscript {
+    this@buildscript.repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-0.11.0")
+    }
+}
+
+//apply(plugin = "love.forte.plugin.suspend-transform")
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven("https://jitpack.io")
+}
+
+android {
+    compileSdk = 34
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+
+    defaultConfig {
+        minSdk = 28
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    packaging {
+        resources {
+            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
+        }
+    }
+}
+
+kotlin {
+    androidTarget {
+        publishLibraryVariants("release")
+    }
+    sourceSets {
+        val androidMain by getting {
+            dependencies {
+                api(project(":waltid-libraries:crypto:waltid-crypto"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+                implementation("io.github.oshai:kotlin-logging:7.0.4")
+            }
+        }
+        val androidInstrumentedTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+                implementation("androidx.test.ext:junit:1.2.1")
+                implementation("androidx.test:runner:1.6.1")
+                implementation("androidx.test:rules:1.6.1")
+            }
+        }
+    }
+}
+
+//extensions.getByType<SuspendTransformGradleExtension>().apply {
+//    includeRuntime = false
+//    includeAnnotation = false
+////     useDefault()
+//}

--- a/tests/test-js/build.gradle.kts
+++ b/tests/test-js/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-0.11.0")
+        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-0.11.1")
     }
 }
 

--- a/tests/test-jvm/build.gradle.kts
+++ b/tests/test-jvm/build.gradle.kts
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-0.11.0")
+        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-0.11.1")
     }
 }
 

--- a/tests/test-kmp/build.gradle.kts
+++ b/tests/test-kmp/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-0.10.0")
+        classpath("love.forte.plugin.suspend-transform:suspend-transform-plugin-gradle:2.1.0-0.11.1")
     }
 }
 


### PR DESCRIPTION
Previously, the handling of compilations in the Gradle plugin appeared to be such that only one compilation was allowed in a `sourceSet`, otherwise an exception would be thrown.

But in android it seems that there may be more than one `compilation` in a source set, e.g., there are two `compilations` [`debug`, `release`] in source set `androidMain`.

Under the old logic, this would have thrown an exception, which is what led to #85.

Fix #85