### PR TITLE
Support `markName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,69 @@ class Foo {
 }
 ```
 
+### MarkName
+
+> since v0.13.0, [#96](https://github.com/ForteScarlet/kotlin-suspend-transform-compiler-plugin/pull/96)
+
+You can use `markName` to add a name mark annotation (e.g. `@JvmName`, `@JsName`) to the generated synthetic function.
+
+For example the JVM:
+
+```kotlin
+class Foo {
+    @JvmBlocking(markName = "namedWaitAndGet")
+    suspend fun waitAndGet(): String {
+        delay(5)
+        return "Hello"
+    } 
+}
+```
+
+compiled 👇
+
+```kotlin
+class Foo {
+    // Hide from Java
+    @JvmSynthetic
+    suspend fun waitAndGet(): String {
+        delay(5)
+        return "Hello"
+    }
+    @Api4J // RequiresOptIn annotation, provide warnings to Kotlin
+    @JvmName("namedWaitAndGet") // From the `markName`'s value
+    fun waitAndGetBlocking(): String = runInBlocking { waitAndGet() } // 'runInBlocking' from the runtime provided by the plugin
+}
+```
+
+Note: `@JvmName` has limitations on non-final functions, and even the compiler may prevent compilation.
+
+For example the JS:
+
+```kotlin
+class Foo {
+    @JsPromise(markName = "namedWaitAndGet")
+    suspend fun waitAndGet(): String {
+        delay(5)
+        return "Hello"
+    } 
+}
+```
+
+compiled 👇
+
+```kotlin
+class Foo {
+    suspend fun waitAndGet(): String {
+        delay(5)
+        return "Hello"
+    }
+  
+    @Api4Js // RequiresOptIn annotation, provide warnings to Kotlin
+    @JsName("namedWaitAndGet") // From the `markName`'s value
+    fun waitAndGetAsync(): Promise<String> = runInAsync { waitAndGet() } // 'runInAsync' from the runtime provided by the plugin
+}
+```
+
 ## Usage
 
 ### The version
@@ -246,7 +309,7 @@ You can also disable them and add dependencies manually.
 ```Kotlin
 plugin {
     kotlin("jvm") version "..." // Take the Kotlin/JVM as an example
-    id("love.forte.plugin.suspend-transform") version "2.1.20-0.12.0"
+    id("love.forte.plugin.suspend-transform") version "<VERSION>"
 }
 
 dependencies {

--- a/README_CN.md
+++ b/README_CN.md
@@ -117,6 +117,69 @@ class Foo {
 }
 ```
 
+### MarkName
+
+> 自 v0.13.0 起, [#96](https://github.com/ForteScarlet/kotlin-suspend-transform-compiler-plugin/pull/96)
+
+你可以使用 `markName` 为生成的合成函数添加名称标记注解（例如 `@JvmName`、`@JsName`）。
+
+例如 JVM：
+
+```kotlin
+class Foo {
+    @JvmBlocking(markName = "namedWaitAndGet")
+    suspend fun waitAndGet(): String {
+        delay(5)
+        return "Hello"
+    } 
+}
+```
+
+编译后 👇
+
+```kotlin
+class Foo {
+    // 对 Java 隐藏
+    @JvmSynthetic
+    suspend fun waitAndGet(): String {
+        delay(5)
+        return "Hello"
+    }
+    @Api4J // 需要显式启用的注解，向 Kotlin 提供警告
+    @JvmName("namedWaitAndGet") // 来自 `markName` 的值
+    fun waitAndGetBlocking(): String = runInBlocking { waitAndGet() } // 'runInBlocking' 来自插件提供的运行时
+}
+```
+
+注意：`@JvmName` 在非 final 函数上有限制，甚至编译器可能会阻止编译。
+
+例如 JS：
+
+```kotlin
+class Foo {
+    @JsPromise(markName = "namedWaitAndGet")
+    suspend fun waitAndGet(): String {
+        delay(5)
+        return "Hello"
+    } 
+}
+```
+
+编译后 👇
+
+```kotlin
+class Foo {
+    suspend fun waitAndGet(): String {
+        delay(5)
+        return "Hello"
+    }
+
+    @Api4Js // 需要显式启用的注解，向 Kotlin 提供警告
+    @JsName("namedWaitAndGet") // 来自 `markName` 的值
+    fun waitAndGetAsync(): Promise<String> = runInAsync { waitAndGet() } // 'runInAsync' 来自插件提供的运行时
+}
+```
+
 ## 使用方式
 
 ### 版本说明
@@ -222,7 +285,7 @@ suspendTransformPlugin {
         // 默认与插件版本相同
         version = "<ANNOTATION_VERSION>"
     }
-    
+
     // 包含运行时
     // 默认为 `true`
     includeRuntime = true
@@ -315,7 +378,7 @@ class Cat {
     suspend fun meow() {
         // ...
     }
-    
+
     // 生成：
     fun meowBlocking() {
         `$runInBlocking$` { meow() }
@@ -345,7 +408,7 @@ suspendTransformPlugin {
 class Cat {
     @JvmBlocking
     suspend fun meow(): String = "Meow!"
-    
+
     // 生成：
     fun meowAsync(): CompletableFuture<out String> {
         `$runInAsync$`(block = { meow() }, scope = this as? CoroutineScope)
@@ -382,7 +445,7 @@ suspendTransformPlugin {
 class Cat {
     @JsPromise
     suspend fun meow(): String = "Meow!"
-    
+
     // 生成：
     fun meowAsync(): Promise<String> {
         `$runInAsync$`(block = { meow() }, scope = this as? CoroutineScope)
@@ -437,7 +500,7 @@ suspendTransformPlugin {
     // 自定义时可能无需默认注解和运行时
     includeAnnotation = false
     includeRuntime = false
-    
+
     transformer {
         // 具体配置见下文
     }
@@ -596,12 +659,12 @@ suspendTransformPlugin {
               defaultSuffix = "Blocking"
               defaultAsProperty = false
             }
-          
+
             transformFunctionInfo {
               packageName = "com.example"
               functionName = "inBlock"
             }
-          
+
             copyAnnotationsToSyntheticFunction = true
             copyAnnotationsToSyntheticProperty = true
 

--- a/buildSrc/src/main/kotlin/IProject.kt
+++ b/buildSrc/src/main/kotlin/IProject.kt
@@ -11,7 +11,7 @@ object IProject : ProjectDetail() {
 
     // Remember the libs.versions.toml!
     val ktVersion = "2.2.0-RC2"
-    val pluginVersion = "0.12.0"
+    val pluginVersion = "0.13.0"
 
     override val version: String = "$ktVersion-$pluginVersion"
 

--- a/compiler/suspend-transform-plugin-configuration/src/main/kotlin/love/forte/plugin/suspendtrans/configuration/SuspendTransformConfiguration.kt
+++ b/compiler/suspend-transform-plugin-configuration/src/main/kotlin/love/forte/plugin/suspendtrans/configuration/SuspendTransformConfiguration.kt
@@ -405,6 +405,17 @@ object SuspendTransformConfigurations {
     //endregion
 
     //region JVM Defaults
+
+    /**
+     * The `kotlin.jvm.JvmName`.
+     * @since 0.13.0
+     */
+    @JvmStatic
+    val jvmNameAnnotationClassInfo = ClassInfo(
+        packageName = KOTLIN_JVM,
+        className = "JvmName"
+    )
+
     @JvmStatic
     val jvmSyntheticClassInfo = ClassInfo(
         packageName = KOTLIN_JVM,
@@ -426,7 +437,12 @@ object SuspendTransformConfigurations {
     @JvmStatic
     val jvmBlockingAnnotationInfo = MarkAnnotation(
         classInfo = jvmBlockingMarkAnnotationClassInfo,
-        defaultSuffix = "Blocking"
+        defaultSuffix = "Blocking",
+        markNameProperty = MarkNameProperty(
+            propertyName = "markName",
+            annotation = jvmNameAnnotationClassInfo,
+            annotationMarkNamePropertyName = "name"
+        )
     )
 
     @JvmStatic
@@ -444,17 +460,12 @@ object SuspendTransformConfigurations {
     @JvmStatic
     val jvmAsyncAnnotationInfo = MarkAnnotation(
         classInfo = jvmAsyncMarkAnnotationClassInfo,
-        defaultSuffix = "Async"
-    )
-
-    /**
-     * The `kotlin.jvm.JvmName`.
-     * @since 0.13.0
-     */
-    @JvmStatic
-    val jvmNameAnnotationClassInfo = ClassInfo(
-        packageName = KOTLIN_JVM,
-        className = "JvmName"
+        defaultSuffix = "Async",
+        markNameProperty = MarkNameProperty(
+            propertyName = "markName",
+            annotation = jvmNameAnnotationClassInfo,
+            annotationMarkNamePropertyName = "name"
+        )
     )
 
     @JvmStatic
@@ -508,6 +519,17 @@ object SuspendTransformConfigurations {
     //endregion
 
     //region JS Defaults
+
+    /**
+     * The `kotlin.js.JsName`.
+     * @since 0.13.0
+     */
+    @JvmStatic
+    val jsNameAnnotationClassInfo = ClassInfo(
+        packageName = KOTLIN_JS,
+        className = "JsName"
+    )
+
     @JvmStatic
     val kotlinJsExportClassInfo = ClassInfo(
         packageName = KOTLIN_JS,
@@ -535,17 +557,12 @@ object SuspendTransformConfigurations {
     @JvmStatic
     val jsAsyncAnnotationInfo = MarkAnnotation(
         classInfo = jsAsyncMarkAnnotationClassInfo,
-        defaultSuffix = "Async"
-    )
-
-    /**
-     * The `kotlin.js.JsName`.
-     * @since 0.13.0
-     */
-    @JvmStatic
-    val jsNameAnnotationClassInfo = ClassInfo(
-        packageName = KOTLIN_JS,
-        className = "JsName"
+        defaultSuffix = "Async",
+        markNameProperty = MarkNameProperty(
+            propertyName = "markName",
+            annotation = jsNameAnnotationClassInfo,
+            annotationMarkNamePropertyName = "name"
+        )
     )
 
     @JvmStatic

--- a/compiler/suspend-transform-plugin-configuration/src/main/kotlin/love/forte/plugin/suspendtrans/configuration/SuspendTransformConfiguration.kt
+++ b/compiler/suspend-transform-plugin-configuration/src/main/kotlin/love/forte/plugin/suspendtrans/configuration/SuspendTransformConfiguration.kt
@@ -3,7 +3,7 @@ package love.forte.plugin.suspendtrans.configuration
 import kotlinx.serialization.Serializable
 
 // NOTE:
-//   可序列号的配置信息均使用 `Protobuf` 进行序列化
+//   配置信息均使用 `Protobuf` 进行序列化
 //   虽然序列化行为是内部的，但是还是应该尽可能避免出现字段的顺序错乱或删改。
 
 @RequiresOptIn(
@@ -77,7 +77,7 @@ enum class TargetPlatform {
 }
 
 /**
- * 用于标记的注解信息.
+ * 用于标记的注解信息, 例如 `@JvmBlocking`, `@JvmAsync`, `@JsPromise`.
  */
 @Serializable
 class MarkAnnotation @InternalSuspendTransformConfigurationApi constructor(
@@ -105,6 +105,13 @@ class MarkAnnotation @InternalSuspendTransformConfigurationApi constructor(
      * 当 [asPropertyProperty] 不存在时使用的默认值
      */
     val defaultAsProperty: Boolean = false,
+
+    /**
+     * A name marker like `@JsName`, `@JvmName`, etc.
+     *
+     * @since 0.13.0
+     */
+    val markNameProperty: MarkNameProperty? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -116,6 +123,7 @@ class MarkAnnotation @InternalSuspendTransformConfigurationApi constructor(
         if (suffixProperty != other.suffixProperty) return false
         if (asPropertyProperty != other.asPropertyProperty) return false
         if (defaultSuffix != other.defaultSuffix) return false
+        if (markNameProperty != other.markNameProperty) return false
 
         return true
     }
@@ -127,11 +135,57 @@ class MarkAnnotation @InternalSuspendTransformConfigurationApi constructor(
         result = 31 * result + suffixProperty.hashCode()
         result = 31 * result + asPropertyProperty.hashCode()
         result = 31 * result + defaultSuffix.hashCode()
+        result = 31 * result + (markNameProperty?.hashCode() ?: 0)
         return result
     }
 
     override fun toString(): String {
-        return "MarkAnnotation(asPropertyProperty='$asPropertyProperty', classInfo=$classInfo, baseNameProperty='$baseNameProperty', suffixProperty='$suffixProperty', defaultSuffix='$defaultSuffix', defaultAsProperty=$defaultAsProperty)"
+        return "MarkAnnotation(asPropertyProperty='$asPropertyProperty', classInfo=$classInfo, baseNameProperty='$baseNameProperty', suffixProperty='$suffixProperty', defaultSuffix='$defaultSuffix', defaultAsProperty=$defaultAsProperty, markName=$markNameProperty)"
+    }
+}
+
+/**
+ * The `markName`'s information.
+ * @since 0.13.0
+ */
+@Serializable
+class MarkNameProperty @InternalSuspendTransformConfigurationApi constructor(
+    /**
+     * The `markName`'s property name of the mark annotation.
+     * e.g. `markName` of `@JsPromise(markName = "foo")
+     */
+    val propertyName: String,
+    /**
+     * The name marker annotation's class info,
+     * e.g. `@JsName`, `@JvmName`, etc.
+     */
+    val annotation: ClassInfo,
+    /**
+     * The name property of name marker annotation,
+     * e.g. `name` of `@JsName(name = "...")`.
+     */
+    val annotationMarkNamePropertyName: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MarkNameProperty) return false
+
+        if (propertyName != other.propertyName) return false
+        if (annotation != other.annotation) return false
+        if (annotationMarkNamePropertyName != other.annotationMarkNamePropertyName) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = propertyName.hashCode()
+        result = 31 * result + annotation.hashCode()
+        result = 31 * result + annotationMarkNamePropertyName.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "MarkName(annotation=$annotation, propertyName='$propertyName', annotationMarkNamePropertyName='$annotationMarkNamePropertyName')"
     }
 }
 

--- a/compiler/suspend-transform-plugin-configuration/src/main/kotlin/love/forte/plugin/suspendtrans/configuration/SuspendTransformConfiguration.kt
+++ b/compiler/suspend-transform-plugin-configuration/src/main/kotlin/love/forte/plugin/suspendtrans/configuration/SuspendTransformConfiguration.kt
@@ -391,10 +391,10 @@ object SuspendTransformConfigurations {
     private const val SUSPENDTRANS_ANNOTATION_PACKAGE = "love.forte.plugin.suspendtrans.annotation"
     private const val SUSPENDTRANS_RUNTIME_PACKAGE = "love.forte.plugin.suspendtrans.runtime"
 
-    private const val JVM_RUN_IN_BLOCKING_FUNCTION_FUNCTION_NAME = "\$runInBlocking\$"
-    private const val JVM_RUN_IN_ASYNC_FUNCTION_FUNCTION_NAME = "\$runInAsync\$"
+    private const val JVM_RUN_IN_BLOCKING_FUNCTION_FUNCTION_NAME = "\$runInBlocking$"
+    private const val JVM_RUN_IN_ASYNC_FUNCTION_FUNCTION_NAME = "\$runInAsync$"
 
-    private const val JS_RUN_IN_ASYNC_FUNCTION_FUNCTION_NAME = "\$runInAsync\$"
+    private const val JS_RUN_IN_ASYNC_FUNCTION_FUNCTION_NAME = "\$runInAsync$"
 
     //region Commons
     @JvmStatic
@@ -447,6 +447,16 @@ object SuspendTransformConfigurations {
         defaultSuffix = "Async"
     )
 
+    /**
+     * The `kotlin.jvm.JvmName`.
+     * @since 0.13.0
+     */
+    @JvmStatic
+    val jvmNameAnnotationClassInfo = ClassInfo(
+        packageName = KOTLIN_JVM,
+        className = "JvmName"
+    )
+
     @JvmStatic
     val jvmAsyncTransformFunction = FunctionInfo(
         packageName = SUSPENDTRANS_RUNTIME_PACKAGE,
@@ -472,6 +482,7 @@ object SuspendTransformConfigurations {
             jvmBlockingMarkAnnotationClassInfo,
             jvmAsyncMarkAnnotationClassInfo,
             kotlinOptInClassInfo,
+            jvmNameAnnotationClassInfo,
         ),
     )
 
@@ -491,6 +502,7 @@ object SuspendTransformConfigurations {
             jvmBlockingMarkAnnotationClassInfo,
             jvmAsyncMarkAnnotationClassInfo,
             kotlinOptInClassInfo,
+            jvmNameAnnotationClassInfo,
         ),
     )
     //endregion
@@ -526,6 +538,16 @@ object SuspendTransformConfigurations {
         defaultSuffix = "Async"
     )
 
+    /**
+     * The `kotlin.js.JsName`.
+     * @since 0.13.0
+     */
+    @JvmStatic
+    val jsNameAnnotationClassInfo = ClassInfo(
+        packageName = KOTLIN_JS,
+        className = "JsName"
+    )
+
     @JvmStatic
     val jsAsyncTransformFunction = FunctionInfo(
         SUSPENDTRANS_RUNTIME_PACKAGE,
@@ -546,6 +568,7 @@ object SuspendTransformConfigurations {
         copyAnnotationExcludes = listOf(
             jsAsyncMarkAnnotationClassInfo,
             kotlinOptInClassInfo,
+            jsNameAnnotationClassInfo,
         )
     )
     //endregion

--- a/compiler/suspend-transform-plugin-configuration/src/main/kotlin/love/forte/plugin/suspendtrans/configuration/SuspendTransformConfiguration.kt
+++ b/compiler/suspend-transform-plugin-configuration/src/main/kotlin/love/forte/plugin/suspendtrans/configuration/SuspendTransformConfiguration.kt
@@ -111,7 +111,8 @@ class MarkAnnotation @InternalSuspendTransformConfigurationApi constructor(
      *
      * @since 0.13.0
      */
-    val markNameProperty: MarkNameProperty? = null,
+    // 'null' is not supported for optional properties in ProtoBuf
+    val markNameProperty: MarkNameProperty?,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/fir/SuspendTransformFirTransformer.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/fir/SuspendTransformFirTransformer.kt
@@ -401,6 +401,8 @@ class SuspendTransformFirTransformer(
                         })
 
                         // TODO What is explicitReceiver?
+                        // this.explicitReceiver
+
                         this.extensionReceiver = thisReceiverParameter?.let { thisReceiverParameter ->
                             buildThisReceiverExpression {
                                 coneTypeOrNull = thisReceiverParameter.typeRef.coneTypeOrNull

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/fir/SuspendTransformFirTransformer.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/fir/SuspendTransformFirTransformer.kt
@@ -1127,11 +1127,12 @@ class SuspendTransformFirTransformer(
                     // Find the marker annotation, e.g., JvmName
                     val markNameAnnotation = buildAnnotation {
                         argumentMapping = buildAnnotationArgumentMapping {
+                            // org.jetbrains.kotlin.fir.java.JavaUtilsKt
                             val markNameArgument = buildLiteralExpression(
-                                source = original.source,
+                                source = null,
                                 kind = ConstantValueKind.String,
                                 value = markName,
-                                setType = false
+                                setType = true
                             )
 
                             val annotationMarkNamePropertyName = markNameProperty.annotationMarkNamePropertyName

--- a/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/CopyAnnotationUtils.kt
+++ b/compiler/suspend-transform-plugin/src/main/kotlin/love/forte/plugin/suspendtrans/utils/CopyAnnotationUtils.kt
@@ -3,13 +3,6 @@ package love.forte.plugin.suspendtrans.utils
 import love.forte.plugin.suspendtrans.configuration.IncludeAnnotation
 import org.jetbrains.kotlin.name.ClassId
 
-data class CopyAnnotationsData(
-    val copyFunction: Boolean,
-    val copyProperty: Boolean,
-    val excludes: List<ClassId>,
-    val includes: List<IncludeAnnotationInfo>
-)
-
 data class IncludeAnnotationInfo(
     val classId: ClassId,
     val repeatable: Boolean,

--- a/compiler/suspend-transform-plugin/src/test-gen/love/forte/plugin/suspendtrans/runners/CodeGenTestRunnerGenerated.java
+++ b/compiler/suspend-transform-plugin/src/test-gen/love/forte/plugin/suspendtrans/runners/CodeGenTestRunnerGenerated.java
@@ -79,4 +79,10 @@ public class CodeGenTestRunnerGenerated extends AbstractCodeGenTestRunner {
   public void testVarargParam() {
     runTest("src/testData/codegen/varargParam.kt");
   }
+
+  @Test
+  @TestMetadata("markName.kt")
+  public void testMarkName() {
+    runTest("src/testData/codegen/markName.kt");
+  }
 }

--- a/compiler/suspend-transform-plugin/src/test/love/forte/plugin/suspendtrans/runners/AbstractTestRunner.kt
+++ b/compiler/suspend-transform-plugin/src/test/love/forte/plugin/suspendtrans/runners/AbstractTestRunner.kt
@@ -4,11 +4,14 @@ import love.forte.plugin.suspendtrans.services.SuspendTransformerEnvironmentConf
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.TargetBackend
+import org.jetbrains.kotlin.test.backend.handlers.AsmLikeInstructionListingHandler
+import org.jetbrains.kotlin.test.backend.handlers.BytecodeListingHandler
 import org.jetbrains.kotlin.test.backend.ir.JvmIrBackendFacade
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.builders.configureFirHandlersStep
 import org.jetbrains.kotlin.test.builders.configureJvmArtifactsHandlersStep
 import org.jetbrains.kotlin.test.configuration.commonConfigurationForJvmTest
+import org.jetbrains.kotlin.test.directives.AsmLikeInstructionListingDirectives.CHECK_ASM_LIKE_INSTRUCTIONS
 import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives.FIR_PARSER
 import org.jetbrains.kotlin.test.frontend.classic.ClassicFrontend2IrConverter
 import org.jetbrains.kotlin.test.frontend.classic.ClassicFrontendFacade
@@ -56,6 +59,7 @@ abstract class AbstractTestRunner : AbstractKotlinCompilerTest() {
 
         builder.defaultDirectives {
             FIR_PARSER with FirParser.LightTree
+            +CHECK_ASM_LIKE_INSTRUCTIONS
         }
 
         when (targetFrontend) {
@@ -90,7 +94,12 @@ abstract class AbstractTestRunner : AbstractKotlinCompilerTest() {
 
         }
 
+        // We need to explicitly configure JVM artifacts handlers to generate .asm files
         builder.configureJvmArtifactsHandlersStep {
+            useHandlers(
+                ::BytecodeListingHandler,
+                ::AsmLikeInstructionListingHandler
+            )
         }
 
         builder.useConfigurators(

--- a/compiler/suspend-transform-plugin/src/testData/codegen/markName.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/markName.fir.txt
@@ -4,18 +4,18 @@ FILE: Main.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|kotlin/jvm/JvmName|(name = String(_foo)) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(markName = String(foo)) @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(markName = String(foo)) @R|kotlin/jvm/JvmSynthetic|() public final suspend fun foo(): R|kotlin/String| {
+        @R|kotlin/jvm/JvmName|(name = String(_foo)) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(markName = String(fooA)) @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(markName = String(fooB)) @R|kotlin/jvm/JvmSynthetic|() public final suspend fun foo(): R|kotlin/String| {
             ^foo String(foo)
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() @R|kotlin/jvm/JvmName|(name = String(foo)) public final fun fooBlocking(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() @R|kotlin/jvm/JvmName|(name = String(fooB)) public final fun fooBlocking(): R|kotlin/String| {
             ^fooBlocking R|love/forte/plugin/suspendtrans/runtime/$runInBlocking$|(suspend fun <anonymous>(): R|kotlin/String| <inline=Unknown>  {
                 ^ this@R|/Foo|.R|/Foo.foo|()
             }
             )
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() @R|kotlin/jvm/JvmName|(name = String(foo)) public final fun fooAsync(): R|java/util/concurrent/CompletableFuture<out kotlin/String>| {
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() @R|kotlin/jvm/JvmName|(name = String(fooA)) public final fun fooAsync(): R|java/util/concurrent/CompletableFuture<out kotlin/String>| {
             ^fooAsync R|love/forte/plugin/suspendtrans/runtime/$runInAsync$|(suspend fun <anonymous>(): R|kotlin/String| <inline=Unknown>  {
                 ^ this@R|/Foo|.R|/Foo.foo|()
             }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/markName.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/markName.fir.txt
@@ -1,0 +1,25 @@
+FILE: Main.kt
+    public final class Foo : R|kotlin/Any| {
+        public constructor(): R|Foo| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|kotlin/jvm/JvmName|(name = String(_foo)) @R|love/forte/plugin/suspendtrans/annotation/JvmAsync|(markName = String(foo)) @R|love/forte/plugin/suspendtrans/annotation/JvmBlocking|(markName = String(foo)) @R|kotlin/jvm/JvmSynthetic|() public final suspend fun foo(): R|kotlin/String| {
+            ^foo String(foo)
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public final fun fooBlocking(): R|kotlin/String| {
+            ^fooBlocking R|love/forte/plugin/suspendtrans/runtime/$runInBlocking$|(suspend fun <anonymous>(): R|kotlin/String| <inline=Unknown>  {
+                ^ this@R|/Foo|.R|/Foo.foo|()
+            }
+            )
+        }
+
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public final fun fooAsync(): R|java/util/concurrent/CompletableFuture<out kotlin/String>| {
+            ^fooAsync R|love/forte/plugin/suspendtrans/runtime/$runInAsync$|(suspend fun <anonymous>(): R|kotlin/String| <inline=Unknown>  {
+                ^ this@R|/Foo|.R|/Foo.foo|()
+            }
+            , (this@R|/Foo| as? R|kotlinx/coroutines/CoroutineScope|))
+        }
+
+    }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/markName.fir.txt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/markName.fir.txt
@@ -8,14 +8,14 @@ FILE: Main.kt
             ^foo String(foo)
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public final fun fooBlocking(): R|kotlin/String| {
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() @R|kotlin/jvm/JvmName|(name = String(foo)) public final fun fooBlocking(): R|kotlin/String| {
             ^fooBlocking R|love/forte/plugin/suspendtrans/runtime/$runInBlocking$|(suspend fun <anonymous>(): R|kotlin/String| <inline=Unknown>  {
                 ^ this@R|/Foo|.R|/Foo.foo|()
             }
             )
         }
 
-        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() public final fun fooAsync(): R|java/util/concurrent/CompletableFuture<out kotlin/String>| {
+        @R|love/forte/plugin/suspendtrans/annotation/Api4J|() @R|kotlin/jvm/JvmName|(name = String(foo)) public final fun fooAsync(): R|java/util/concurrent/CompletableFuture<out kotlin/String>| {
             ^fooAsync R|love/forte/plugin/suspendtrans/runtime/$runInAsync$|(suspend fun <anonymous>(): R|kotlin/String| <inline=Unknown>  {
                 ^ this@R|/Foo|.R|/Foo.foo|()
             }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/markName.kt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/markName.kt
@@ -8,7 +8,7 @@ import love.forte.plugin.suspendtrans.annotation.JvmBlocking
 
 class Foo {
     @JvmName("_foo")
-    @JvmAsync(markName = "foo")
-    @JvmBlocking(markName = "foo")
+    @JvmAsync(markName = "fooA")
+    @JvmBlocking(markName = "fooB")
     suspend fun foo(): String = "foo"
 }

--- a/compiler/suspend-transform-plugin/src/testData/codegen/markName.kt
+++ b/compiler/suspend-transform-plugin/src/testData/codegen/markName.kt
@@ -1,0 +1,14 @@
+// FIR_DUMP
+// DUMP_IR
+// SOURCE
+// FILE: Main.kt [MainKt#main]
+
+import love.forte.plugin.suspendtrans.annotation.JvmAsync
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
+
+class Foo {
+    @JvmName("_foo")
+    @JvmAsync(markName = "foo")
+    @JvmBlocking(markName = "foo")
+    suspend fun foo(): String = "foo"
+}

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1758,6 +1758,11 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.npmmirror.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
+
 ua-parser-js@^0.7.30:
   version "0.7.37"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.37.tgz#e464e66dac2d33a7a1251d7d7a99d6157ec27832"

--- a/plugins/suspend-transform-plugin-gradle/src/main/kotlin/love/forte/plugin/suspendtrans/gradle/SuspendTransformGradlePlugin.kt
+++ b/plugins/suspend-transform-plugin-gradle/src/main/kotlin/love/forte/plugin/suspendtrans/gradle/SuspendTransformGradlePlugin.kt
@@ -220,7 +220,8 @@ private fun DeprecatedMarkAnnotation.toMarkAnnotation(): MarkAnnotation {
         suffixProperty = this.suffixProperty,
         asPropertyProperty = this.asPropertyProperty,
         defaultSuffix = this.defaultSuffix,
-        defaultAsProperty = this.defaultAsProperty
+        defaultAsProperty = this.defaultAsProperty,
+        markNameProperty = null,
     )
 }
 
@@ -265,7 +266,7 @@ private fun SuspendTransformPluginExtension.toSubpluginOptionsProvider(
                 return@flatMap project.provider { emptyList() }
             }
 
-            val configurationProvider = toConfigurationProvider(project.objects)
+            val configurationProvider = toConfigurationProvider(project, project.objects)
 
             configurationProvider.map { configuration ->
                 val transformers = configuration.transformers

--- a/plugins/suspend-transform-plugin-gradle/src/main/kotlin/love/forte/plugin/suspendtrans/gradle/SuspendTransformPluginExtension.kt
+++ b/plugins/suspend-transform-plugin-gradle/src/main/kotlin/love/forte/plugin/suspendtrans/gradle/SuspendTransformPluginExtension.kt
@@ -155,7 +155,6 @@ abstract class TransformersContainer
     override val factory: SuspendTransformPluginExtensionSpecFactory =
         SuspendTransformPluginExtensionSpecFactoryImpl(objects)
 
-    //     mutableMapOf()
     internal val containers: MutableMap<TargetPlatform, ListProperty<TransformerSpec>> =
         EnumMap(TargetPlatform::class.java)
     // TODO Maybe ...
@@ -170,7 +169,6 @@ abstract class TransformersContainer
 
 
     private fun getTransformersInternal(platform: TargetPlatform): ListProperty<TransformerSpec> {
-        // return containers.maybeCreate(platform.name).transformerSet
         return containers.computeIfAbsent(platform) { objects.listProperty(TransformerSpec::class.java) }
     }
 
@@ -857,10 +855,16 @@ abstract class MarkNamePropertySpec
      */
     abstract val annotation: Property<MarkNameAnnotationSpec>
 
+    /**
+     * The name marker annotation.
+     */
     fun annotation(action: Action<in MarkNameAnnotationSpec>) {
         annotation.set(annotation.getOrElse(objects.newInstance<MarkNameAnnotationSpec>()).also(action::execute))
     }
 
+    /**
+     * The name marker annotation.
+     */
     fun annotation(action: MarkNameAnnotationSpec.() -> Unit) {
         annotation.set(annotation.getOrElse(objects.newInstance<MarkNameAnnotationSpec>()).also(action))
     }
@@ -885,17 +889,15 @@ abstract class MarkNamePropertySpec
  *
  * @since 0.13.0
  */
-abstract class MarkNameAnnotationSpec
-@Inject constructor(private val objects: ObjectFactory) :
-    SuspendTransformPluginExtensionSpec, ClassNameSpec {
-    abstract override val className: Property<String>
-    abstract override val packageName: Property<String>
+interface MarkNameAnnotationSpec : SuspendTransformPluginExtensionSpec, ClassNameSpec {
+    override val className: Property<String>
+    override val packageName: Property<String>
 
     /**
      * The name's property name,
      * e.g. `name` of `@JsName(name = "...")`, `name` of `@JvmName(name = "...")`, etc.
      */
-    abstract val propertyName: Property<String>
+    val propertyName: Property<String>
 }
 
 /**

--- a/runtime/suspend-transform-annotation/src/commonMain/kotlin/love/forte/plugin/suspendtrans/annotation/SuspendTransformAnnotation.kt
+++ b/runtime/suspend-transform-annotation/src/commonMain/kotlin/love/forte/plugin/suspendtrans/annotation/SuspendTransformAnnotation.kt
@@ -62,7 +62,19 @@ public expect annotation class JvmBlocking(
      * Note: If [asProperty] == `true`, the function cannot have parameters.
      *
      */
-    val asProperty: Boolean = false
+    val asProperty: Boolean = false,
+
+    /**
+     * The name of `@JvmName`.
+     * Valid when not empty.
+     *
+     * If multiple markNames are effective for the same function on the same platform,
+     * an exception will be generated during the compilation period.
+     *
+     * Note: In the JVM, adding `@JvmName` to a non-final function is usually not allowed by the compiler.
+     * @since 0.13.0
+     */
+    val markName: String = "",
 )
 
 /**
@@ -101,7 +113,19 @@ public expect annotation class JvmAsync(
      *
      * Note: If [asProperty] == `true`, the function cannot have parameters.
      */
-    val asProperty: Boolean = false
+    val asProperty: Boolean = false,
+
+    /**
+     * The name of `@JvmName`.
+     * Valid when not empty.
+     *
+     * If multiple markNames are effective for the same function on the same platform,
+     * an exception will be generated during the compilation period.
+     *
+     * Note: In the JVM, adding `@JvmName` to a non-final function is usually not allowed by the compiler.
+     * @since 0.13.0
+     */
+    val markName: String = "",
 )
 
 
@@ -125,5 +149,16 @@ public expect annotation class JsPromise(
      * Note: If [asProperty] == `true`, the function cannot have parameters.
      *
      */
-    val asProperty: Boolean = false
+    val asProperty: Boolean = false,
+
+    /**
+     * The name of `@JsName`.
+     * Valid when not empty.
+     *
+     * If multiple markNames are effective for the same function on the same platform,
+     * an exception will be generated during the compilation period.
+     *
+     * @since 0.13.0
+     */
+    val markName: String = "",
 )

--- a/runtime/suspend-transform-annotation/src/commonMain/kotlin/love/forte/plugin/suspendtrans/annotation/SuspendTransformAnnotation.kt
+++ b/runtime/suspend-transform-annotation/src/commonMain/kotlin/love/forte/plugin/suspendtrans/annotation/SuspendTransformAnnotation.kt
@@ -68,8 +68,18 @@ public expect annotation class JvmBlocking(
      * The name of `@JvmName`.
      * Valid when not empty.
      *
-     * If multiple markNames are effective for the same function on the same platform,
-     * an exception will be generated during the compilation period.
+     * If [markName] is valid, [kotlin.jvm.JvmName] will be annotated on the generated function.
+     *
+     * For example:
+     *
+     * ```Kotlin
+     * @JvmBlocking(markName = "markName_foo")
+     * suspend fun foo(): String = "..."
+     *
+     * // The generated fun:
+     * @JvmName(name = "markName_foo")
+     * fun fooBlocking(): String = runBlocking { foo() }
+     * ```
      *
      * Note: In the JVM, adding `@JvmName` to a non-final function is usually not allowed by the compiler.
      * @since 0.13.0
@@ -116,11 +126,21 @@ public expect annotation class JvmAsync(
     val asProperty: Boolean = false,
 
     /**
-     * The name of `@JvmName`.
+     * The name of [@JvmName][kotlin.jvm.JvmName].
      * Valid when not empty.
      *
-     * If multiple markNames are effective for the same function on the same platform,
-     * an exception will be generated during the compilation period.
+     * If [markName] is valid, [@JvmName][kotlin.jvm.JvmName] will be annotated on the generated function.
+     *
+     * For example:
+     *
+     * ```Kotlin
+     * @JvmBlocking(markName = "markName_foo")
+     * suspend fun foo(): String = "..."
+     *
+     * // The generated fun:
+     * @JvmName(name = "markName_foo")
+     * fun fooBlocking(): String = runBlocking { foo() }
+     * ```
      *
      * Note: In the JVM, adding `@JvmName` to a non-final function is usually not allowed by the compiler.
      * @since 0.13.0
@@ -152,11 +172,22 @@ public expect annotation class JsPromise(
     val asProperty: Boolean = false,
 
     /**
-     * The name of `@JsName`.
+     * The name of [@JsName][kotlin.js.JsName].
      * Valid when not empty.
      *
-     * If multiple markNames are effective for the same function on the same platform,
-     * an exception will be generated during the compilation period.
+     * If [markName] is valid, [@JsName][kotlin.js.JsName] will be annotated on the generated function.
+     *
+     * For example:
+     *
+     * ```Kotlin
+     * @JsPromise(markName = "markName_foo")
+     * suspend fun foo(): String = "..."
+     *
+     * // The generated fun:
+     * @JsName(name = "markName_foo")
+     * fun fooAsync(): Promise<out String> = runAsync { foo() }
+     * ```
+     *
      *
      * @since 0.13.0
      */

--- a/runtime/suspend-transform-annotation/src/jsMain/kotlin/love.forte.plugin.suspendtrans/annotation/SuspendTransformAnnotationJs.kt
+++ b/runtime/suspend-transform-annotation/src/jsMain/kotlin/love.forte.plugin.suspendtrans/annotation/SuspendTransformAnnotationJs.kt
@@ -14,4 +14,26 @@ public actual annotation class JsPromise(
     actual val baseName: String,
     actual val suffix: String,
     actual val asProperty: Boolean,
+
+    /**
+     * The name of [@JsName][kotlin.js.JsName].
+     * Valid when not empty.
+     *
+     * If [markName] is valid, [@JsName][kotlin.js.JsName] will be annotated on the generated function.
+     *
+     * For example:
+     *
+     * ```Kotlin
+     * @JsPromise(markName = "markName_foo")
+     * suspend fun foo(): String = "..."
+     *
+     * // The generated fun:
+     * @JsName(name = "markName_foo")
+     * fun fooAsync(): Promise<out String> = runAsync { foo() }
+     * ```
+     *
+     *
+     * @since 0.13.0
+     */
+    actual val markName: String = "",
 )

--- a/runtime/suspend-transform-annotation/src/jvmMain/kotlin/love.forte.plugin.suspendtrans/annotation/SuspendTransformAnnotationJvm.kt
+++ b/runtime/suspend-transform-annotation/src/jvmMain/kotlin/love.forte.plugin.suspendtrans/annotation/SuspendTransformAnnotationJvm.kt
@@ -55,6 +55,15 @@ public actual annotation class JvmBlocking(
      *
      */
     actual val asProperty: Boolean,
+
+    /**
+     * The name of `@JvmName`.
+     * Valid when not empty.
+     *
+     * Note: In the JVM, adding `@JvmName` to a non-final function is usually not allowed by the compiler.
+     * @since 0.13.0
+     */
+    actual val markName: String = "",
 )
 
 /**
@@ -80,4 +89,13 @@ public actual annotation class JvmAsync(
     actual val baseName: String,
     actual val suffix: String,
     actual val asProperty: Boolean,
+
+    /**
+     * The name of `@JvmName`.
+     * Valid when not empty.
+     *
+     * Note: In the JVM, adding `@JvmName` to a non-final function is usually not allowed by the compiler.
+     * @since 0.13.0
+     */
+    actual val markName: String = "",
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,7 @@ include(":plugins:suspend-transform-plugin-gradle")
 // include(":local-helper")
 
 //Samples
-// include(":tests:test-jvm")
-// include(":tests:test-js")
-// include(":tests:test-kmp")
+//include(":tests:test-jvm")
+//include(":tests:test-js")
+//include(":tests:test-kmp")
 // include(":tests:test-android")

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("love.forte.plugin.suspend-transform") version "2.1.20-0.12.0" apply false
+    id("love.forte.plugin.suspend-transform") version "2.2.0-RC2-0.13.0" apply false
 }

--- a/tests/test-js/build.gradle.kts
+++ b/tests/test-js/build.gradle.kts
@@ -10,8 +10,6 @@ repositories {
     mavenLocal()
 }
 
-apply(plugin = "love.forte.plugin.suspend-transform")
-
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     compilerOptions {
@@ -51,18 +49,6 @@ kotlin {
     }
 }
 
-// suspendTransformPlugin {
-//     includeRuntime = false
-//     includeAnnotation = false
-//     transformers {
-//         addJsPromise {
-//             addCopyAnnotationExclude {
-//                 from(kotlinJsExportIgnoreClassInfo)
-//             }
-//         }
-//     }
-// }
-
 suspendTransformPlugin {
     includeRuntime = false
     includeAnnotation = false
@@ -80,17 +66,3 @@ suspendTransformPlugin {
         }
     }
 }
-
-// extensions.getByType<SuspendTransformGradleExtension>().apply {
-//     includeRuntime = false
-//     includeAnnotation = false
-//
-//     transformers[TargetPlatform.JS] = mutableListOf(
-//         SuspendTransformConfiguration.jsPromiseTransformer.copy(
-//             copyAnnotationExcludes = listOf(
-//                 ClassInfo("kotlin.js", "JsExport.Ignore")
-//             )
-//         )
-//     )
-//
-// }

--- a/tests/test-js/src/commonMain/kotlin/markname/MarkNameTestClass.kt
+++ b/tests/test-js/src/commonMain/kotlin/markname/MarkNameTestClass.kt
@@ -1,0 +1,72 @@
+package markname
+
+import love.forte.plugin.suspendtrans.annotation.JsPromise
+
+@Suppress("RedundantSuspendModifier")
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+class MarkNameTestClass {
+    @JsPromise(markName = "foo")
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int = 1
+
+    @JsName("aName")
+    fun named(): String = ""
+}
+
+@Suppress("RedundantSuspendModifier")
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@JsPromise(markName = "foo")
+class MarkNameOnTypeTestClass {
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int = 1
+}
+
+@Suppress("RedundantSuspendModifier")
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@JsPromise(markName = "foo")
+class MarkNameSubOverwriteTestClass {
+    @JsPromise(markName = "foo1")
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int = 1
+}
+
+@Suppress("RedundantSuspendModifier")
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+class MarkNameTestClassAsProperty {
+    @JsPromise(asProperty = true, markName = "foo")
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int = 1
+
+    val named: String
+        @JsName("aName")
+        get() = ""
+}
+
+@Suppress("RedundantSuspendModifier")
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@JsPromise(asProperty = true, markName = "foo")
+class MarkNameOnTypeTestClassAsProperty {
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int = 1
+}
+
+@Suppress("RedundantSuspendModifier")
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@JsPromise(markName = "foo")
+class MarkNameSubOverwriteTestClassAsProperty {
+    @JsPromise(asProperty = true, markName = "foo1")
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int = 1
+}

--- a/tests/test-js/src/commonMain/kotlin/markname/MarkNameTestInterface.kt
+++ b/tests/test-js/src/commonMain/kotlin/markname/MarkNameTestInterface.kt
@@ -1,0 +1,59 @@
+package markname
+
+import love.forte.plugin.suspendtrans.annotation.JsPromise
+
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+interface MarkNameTestInterface {
+    @JsPromise(markName = "foo")
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int
+}
+
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@JsPromise(markName = "foo")
+interface MarkNameOnTypeTestInterface {
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int
+}
+
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@JsPromise(markName = "foo")
+interface MarkNameSubOverwriteTestInterface {
+    @JsName("_foo")
+    @JsExport.Ignore
+    @JsPromise(markName = "foo1")
+    suspend fun foo(): Int
+}
+
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+interface MarkNameTestInterfaceAsProperty {
+    @JsPromise(asProperty = true, markName = "foo")
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int
+}
+
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@JsPromise(asProperty = true, markName = "foo")
+interface MarkNameOnTypeTestInterfaceAsProperty {
+    @JsName("_foo")
+    @JsExport.Ignore
+    suspend fun foo(): Int
+}
+
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@JsPromise(markName = "foo")
+interface MarkNameSubOverwriteTestInterfaceAsProperty {
+    @JsName("_foo")
+    @JsExport.Ignore
+    @JsPromise(asProperty = true, markName = "foo1")
+    suspend fun foo(): Int
+}

--- a/tests/test-js/src/jsTest/kotlin/markname/MarkNameTests.kt
+++ b/tests/test-js/src/jsTest/kotlin/markname/MarkNameTests.kt
@@ -1,0 +1,67 @@
+package markname
+
+import kotlinx.coroutines.await
+import kotlinx.coroutines.test.runTest
+import kotlin.js.Promise
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+
+class MarkNameTests {
+    @Test
+    fun testMarkNameClass() = runTest {
+        val fooResult = MarkNameTestClass().asDynamic().foo()
+        assertIs<Promise<Int>>(fooResult)
+        assertEquals(1, fooResult.unsafeCast<Promise<Int>>().await())
+    }
+
+    @Test
+    fun testMarkNameClassOnType() = runTest {
+        val fooResult = MarkNameOnTypeTestClass().asDynamic().foo()
+        assertIs<Promise<Int>>(fooResult)
+        assertEquals(1, fooResult.unsafeCast<Promise<Int>>().await())
+    }
+
+    @Test
+    fun testMarkNameClassSubOverwrite() = runTest {
+        val fooResult = MarkNameSubOverwriteTestClass().asDynamic().foo1()
+        assertIs<Promise<Int>>(fooResult)
+        assertEquals(1, fooResult.unsafeCast<Promise<Int>>().await())
+    }
+
+    @Test
+    fun testMarkNameInterface() = runTest {
+        val fooResult = object : MarkNameTestInterface {
+            override suspend fun foo(): Int = 1
+        }.asDynamic().foo()
+        assertIs<Promise<Int>>(fooResult)
+        assertEquals(1, fooResult.unsafeCast<Promise<Int>>().await())
+    }
+
+    @Test
+    fun testMarkNameInterfaceOnType() = runTest {
+        val fooResult = object : MarkNameOnTypeTestInterface {
+            override suspend fun foo(): Int = 1
+        }.asDynamic().foo()
+        assertIs<Promise<Int>>(fooResult)
+        assertEquals(1, fooResult.unsafeCast<Promise<Int>>().await())
+    }
+
+    @Test
+    fun testMarkNameInterfaceSubOverwrite() = runTest {
+        val fooResult = object : MarkNameSubOverwriteTestInterface {
+            override suspend fun foo(): Int = 1
+        }.asDynamic().foo1()
+        assertIs<Promise<Int>>(fooResult)
+        assertEquals(1, fooResult.unsafeCast<Promise<Int>>().await())
+    }
+
+    // TODO see https://youtrack.jetbrains.com/issue/KT-78473
+//    @Test
+//    fun testMarkNameClassAsProperty() = runTest {
+//        val fooResult = MarkNameTestClassAsProperty().asDynamic().foo
+//        assertIs<Promise<Int>>(fooResult)
+//        assertEquals(1, fooResult.unsafeCast<Promise<Int>>().await())
+//    }
+}

--- a/tests/test-jvm/src/main/kotlin/love/forte/plugin/suspendtrans/sample/markname/MarkNameTestClass.kt
+++ b/tests/test-jvm/src/main/kotlin/love/forte/plugin/suspendtrans/sample/markname/MarkNameTestClass.kt
@@ -1,0 +1,60 @@
+package love.forte.plugin.suspendtrans.sample.markname
+
+import love.forte.plugin.suspendtrans.annotation.JvmAsync
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
+
+@Suppress("RedundantSuspendModifier")
+class MarkNameTestClass {
+    @JvmBlocking(markName = "fooB")
+    @JvmAsync(markName = "fooA")
+    @JvmName("_foo")
+    suspend fun foo(): Int = 1
+
+    @JvmName("aName")
+    fun named(): String = ""
+}
+
+@Suppress("RedundantSuspendModifier")
+@JvmBlocking(markName = "fooB")
+@JvmAsync(markName = "fooA")
+class MarkNameOnTypeTestClass {
+    @JvmName("_foo")
+    suspend fun foo(): Int = 1
+}
+
+@Suppress("RedundantSuspendModifier")
+@JvmBlocking(markName = "fooB")
+@JvmAsync(markName = "fooA")
+class MarkNameSubOverwriteTestClass {
+    @JvmBlocking(markName = "fooB1")
+    @JvmAsync(markName = "fooA1")
+    suspend fun foo(): Int = 1
+}
+
+@Suppress("RedundantSuspendModifier")
+class MarkNameTestClassAsProperty {
+    @JvmBlocking(asProperty = true, markName = "fooB")
+    @JvmAsync(asProperty = true, markName = "fooA")
+    @JvmName("_foo")
+    suspend fun foo(): Int = 1
+
+    @JvmName("aName")
+    fun named(): String = ""
+}
+
+@Suppress("RedundantSuspendModifier")
+@JvmBlocking(asProperty = true, markName = "fooB")
+@JvmAsync(asProperty = true, markName = "fooA")
+class MarkNameOnTypeTestClassAsProperty {
+    @JvmName("_foo")
+    suspend fun foo(): Int = 1
+}
+
+@Suppress("RedundantSuspendModifier")
+@JvmBlocking(markName = "fooB")
+@JvmAsync(markName = "fooA")
+class MarkNameSubOverwriteTestClassAsProperty {
+    @JvmBlocking(asProperty = true, markName = "fooB1")
+    @JvmAsync(asProperty = true, markName = "fooA1")
+    suspend fun foo(): Int = 1
+}

--- a/tests/test-jvm/src/test/kotlin/markname/MarkNameTests.kt
+++ b/tests/test-jvm/src/test/kotlin/markname/MarkNameTests.kt
@@ -1,0 +1,115 @@
+package markname
+
+import love.forte.plugin.suspendtrans.sample.markname.*
+import java.util.concurrent.CompletableFuture
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.javaGetter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+
+@Suppress("UNCHECKED_CAST")
+class MarkNameTests {
+    @Test
+    fun testMarkNameClass() {
+        val clz = MarkNameTestClass()
+        val blockMethod = MarkNameTestClass::class.java.getMethod("fooB")
+        assertEquals(Int::class.javaPrimitiveType, blockMethod.returnType)
+        assertEquals(1, blockMethod.invoke(clz))
+        val asyncMethod = MarkNameTestClass::class.java.getMethod("fooA")
+        assertEquals(CompletableFuture::class.java, asyncMethod.returnType)
+        val asyncResult = asyncMethod.invoke(clz) as CompletableFuture<Int>
+        assertEquals(1, asyncResult.join())
+    }
+
+
+    @Test
+    fun testMarkNameClassOnType() {
+        val clz = MarkNameOnTypeTestClass()
+        val blockMethod = MarkNameOnTypeTestClass::class.java.getMethod("fooB")
+        assertEquals(Int::class.javaPrimitiveType, blockMethod.returnType)
+        assertEquals(1, blockMethod.invoke(clz))
+        val asyncMethod = MarkNameOnTypeTestClass::class.java.getMethod("fooA")
+        assertEquals(CompletableFuture::class.java, asyncMethod.returnType)
+        val asyncResult = asyncMethod.invoke(clz) as CompletableFuture<Int>
+        assertEquals(1, asyncResult.join())
+    }
+
+    @Test
+    fun testMarkNameClassSubOverwrite() {
+        val clz = MarkNameSubOverwriteTestClass()
+        val blockMethod = MarkNameSubOverwriteTestClass::class.java.getMethod("fooB1")
+        assertEquals(Int::class.javaPrimitiveType, blockMethod.returnType)
+        assertEquals(1, blockMethod.invoke(clz))
+        val asyncMethod = MarkNameSubOverwriteTestClass::class.java.getMethod("fooA1")
+        assertEquals(CompletableFuture::class.java, asyncMethod.returnType)
+        val asyncResult = asyncMethod.invoke(clz) as CompletableFuture<Int>
+        assertEquals(1, asyncResult.join())
+    }
+
+    @Test
+    fun testMarkNameClassAsProperty() {
+        val clz = MarkNameTestClassAsProperty()
+        val blockProp = MarkNameTestClassAsProperty::class.memberProperties.find { it.name == "fooBlocking" }
+        assertNotNull(blockProp)
+        val blockMethod = blockProp.javaGetter
+        assertNotNull(blockMethod)
+        assertEquals("fooB", blockMethod.name)
+        assertEquals(Int::class.javaPrimitiveType, blockMethod.returnType)
+        assertEquals(1, blockMethod.invoke(clz))
+
+        val asyncProp = MarkNameTestClassAsProperty::class.memberProperties.find { it.name == "fooAsync" }
+        assertNotNull(asyncProp)
+        val asyncMethod = asyncProp.javaGetter
+        assertNotNull(asyncMethod)
+        assertEquals("fooA", asyncMethod.name)
+        assertEquals(CompletableFuture::class.java, asyncMethod.returnType)
+        val asyncResult = asyncMethod.invoke(clz) as CompletableFuture<Int>
+        assertEquals(1, asyncResult.join())
+    }
+
+    @Test
+    fun testMarkNameClassOnTypeAsProperty() {
+        val clz = MarkNameOnTypeTestClassAsProperty()
+        val blockProp = MarkNameOnTypeTestClassAsProperty::class.memberProperties.find { it.name == "fooBlocking" }
+        assertNotNull(blockProp)
+        val blockMethod = blockProp.javaGetter
+        assertNotNull(blockMethod)
+        assertEquals("fooB", blockMethod.name)
+        assertEquals(Int::class.javaPrimitiveType, blockMethod.returnType)
+        assertEquals(1, blockMethod.invoke(clz))
+
+        val asyncProp = MarkNameOnTypeTestClassAsProperty::class.memberProperties.find { it.name == "fooAsync" }
+        assertNotNull(asyncProp)
+        val asyncMethod = asyncProp.javaGetter
+        assertNotNull(asyncMethod)
+        assertEquals("fooA", asyncMethod.name)
+        assertEquals(CompletableFuture::class.java, asyncMethod.returnType)
+        val asyncResult = asyncMethod.invoke(clz) as CompletableFuture<Int>
+        assertEquals(1, asyncResult.join())
+    }
+
+    @Test
+    fun testMarkNameClassSubOverwriteAsProperty() {
+        val clz = MarkNameSubOverwriteTestClassAsProperty()
+        val blockProp =
+            MarkNameSubOverwriteTestClassAsProperty::class.memberProperties.find { it.name == "fooBlocking" }
+        assertNotNull(blockProp)
+        val blockMethod = blockProp.javaGetter
+        assertNotNull(blockMethod)
+        assertEquals("fooB1", blockMethod.name)
+        assertEquals(Int::class.javaPrimitiveType, blockMethod.returnType)
+        assertEquals(1, blockMethod.invoke(clz))
+
+        val asyncProp = MarkNameSubOverwriteTestClassAsProperty::class.memberProperties.find { it.name == "fooAsync" }
+        assertNotNull(asyncProp)
+        val asyncMethod = asyncProp.javaGetter
+        assertNotNull(asyncMethod)
+        assertEquals("fooA1", asyncMethod.name)
+        assertEquals(CompletableFuture::class.java, asyncMethod.returnType)
+        val asyncResult = asyncMethod.invoke(clz) as CompletableFuture<Int>
+        assertEquals(1, asyncResult.join())
+    }
+
+}

--- a/tests/test-kmp/build.gradle.kts
+++ b/tests/test-kmp/build.gradle.kts
@@ -1,3 +1,5 @@
+import love.forte.plugin.suspendtrans.configuration.SuspendTransformConfigurations
+
 plugins {
     kotlin("multiplatform")
     id("love.forte.plugin.suspend-transform")
@@ -13,8 +15,6 @@ kotlin {
 repositories {
     mavenLocal()
 }
-
-apply(plugin = "love.forte.plugin.suspend-transform")
 
 kotlin {
 
@@ -81,17 +81,17 @@ suspendTransformPlugin {
 }
 
 @Suppress("DEPRECATION")
-suspendTransform {
+suspendTransformPlugin {
     includeRuntime = false
     includeAnnotation = false
-    useJvmDefault()
-    addJsTransformers(
-        love.forte.plugin.suspendtrans.SuspendTransformConfiguration.jsPromiseTransformer.copy(
-            copyAnnotationExcludes = listOf(
-                love.forte.plugin.suspendtrans.ClassInfo("kotlin.js", "JsExport.Ignore")
-            )
-        )
-    )
+    transformers {
+        useJvmDefault()
+        addJsPromise {
+            addCopyAnnotationExclude {
+                from(SuspendTransformConfigurations.kotlinJsExportIgnoreClassInfo)
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
see #95

Adds the property `markName` to each of the three existing annotations (`JvmBlocking`, `JvmAsync`, `JsPromise`) in the `runtime`, which, when specified, adds the corresponding annotation (`@JvmName`, `@JsName`) to the generated function (or getter of the property).

> [!warning]
> Known issues: [KT-78473](https://youtrack.jetbrains.com/issue/KT-78473): `@JsName` does not work for `@JsExport` with property's getter, This may require waiting for an official Kotlin answer or fix for this issue.
> 
> There is no effect on the function, and it works fine.

In addition, the `markNameProperty` property has been added to the `markAnnotation` configuration item to allow customization of any behavior related to `markName`, e.g., by adding `@Deprecated("${markName}")` or something like that (or maybe you write your own custom annotation?).

For example, the `build.gradle.kts`:
```Kotlin
suspendTransformPlugin {
    transformers {
        // others...
        addJvm {
            // others...
            markAnnotation {
                // others...
                // config your mark name property here
                markNameProperty {
                    propertyName = "markName" // The property name in your mark annotation
                    annotation {
                        packageName = "kotlin"
                        className = "Deprecated"
                        propertyName = "message" // The message in @Deprecated(message = "...")
                    }
                }
            }
        }
    }
}
```

> NOTE: There are some limitations: you can only specify one annotation, and you can only specify one of its string-type parameters.

> NOTE: There will be more restrictions in the JVM, such as the compiler warning or rejecting when using `@JvmName` on a non-final function.