### PR TITLE
bump dependencies to latest kotlin 2.2 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlinx-coroutines = "1.8.0"
-kotlinx-serialization = "1.7.1"
+kotlinx-coroutines = "1.10.2"
+kotlinx-serialization = "1.9.0"
 google-auto-service = "1.0.1"
 # Remember the `IProject.ktVersion`!
 kotlin = "2.2.10"


### PR DESCRIPTION
Your kotlin version is very up to date, but your dependencies are quite far behind. I'm on a project with kotlin 2.1, but with newer package versions, and I am running into conflicts